### PR TITLE
fix: Added support to MsSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ Now, Casdoor is running on port 8000. You can access Casdoor pages directly in y
 
   Casdoor uses XORM to connect to DB, so all DBs supported by XORM can also be used.
 
+  ### MSSQL Support
+  To use MsSQL instead of MySQL, change in app.conf 'dbAdapter' to 'mssql' and set your dataSourceName as:
+  ``` INI
+    dataSourceName = sqlserver://user:pass@ip.ad.dre.ss/instance?database=dbName
+  ```
+  
+  Then, create a database named as dbName in app.conf (where 'casdoor' is the default database name)
+  ``` SQL
+   IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'casdoor') BEGIN CREATE DATABASE casdoor END; 
+  ```
+
+
 - Setup your Casdoor to enable some third-party login platform:
 
   Casdoor provide a way to sign up using Google account, Github account, WeChat account and so on,  so you may have to get your own  ClientID and ClientSecret first.

--- a/authz/authz.go
+++ b/authz/authz.go
@@ -27,7 +27,7 @@ var Enforcer *casbin.Enforcer
 func InitAuthz() {
 	var err error
 
-	a, err := xormadapter.NewAdapter("mysql", beego.AppConfig.String("dataSourceName")+beego.AppConfig.String("dbName"), true)
+	a, err := xormadapter.NewAdapter(beego.AppConfig.String("dbAdapter"), beego.AppConfig.String("dataSourceName"), true)
 	if err != nil {
 		panic(err)
 	}

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -3,6 +3,7 @@ httpport = 8000
 runmode = dev
 SessionOn = true
 copyrequestbody = true
+dbAdapter = mysql
 dataSourceName = root:123@tcp(localhost:3306)/
 dbName = casdoor
 AuthState = "casdoor"

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/casbin/casbin/v2 v2.23.4
 	github.com/casbin/xorm-adapter/v2 v2.2.0
+	github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/cupcake/rdb v0.0.0-20161107195141-43ba34106c76/go.mod h1:vYwsqCOLxGii
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc h1:VRRKCwnzqk8QCaRC4os14xoKDdbHqqlJtJA0oc1ZAjg=
 github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -68,6 +69,7 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=


### PR DESCRIPTION
Hi. I've added support to interface casdoor with a MsSQL database.
The only issue is that you can't create the database by engine.Exec and you must specify the database name in the connection string (I've updated the README to explain it, if needed)