### PR TITLE
.gitignore add ".swp"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.swp
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
ignore `.swp` files, which may be created by editors like `vim` on linux.