### PR TITLE
feat: authorize via clientId and clientSecret

### DIFF
--- a/object/application.go
+++ b/object/application.go
@@ -116,7 +116,7 @@ func GetApplicationByUser(user *User) *Application {
 	return GetApplicationByOrganizationName(user.Owner)
 }
 
-func getApplicationByClientId(clientId string) *Application {
+func GetApplicationByClientId(clientId string) *Application {
 	application := Application{}
 	existed, err := adapter.Engine.Where("client_id=?", clientId).Get(&application)
 	if err != nil {

--- a/object/token.go
+++ b/object/token.go
@@ -129,7 +129,7 @@ func CheckOAuthLogin(clientId string, responseType string, redirectUri string, s
 		return "response_type should be \"code\"", nil
 	}
 
-	application := getApplicationByClientId(clientId)
+	application := GetApplicationByClientId(clientId)
 	if application == nil {
 		return "Invalid client_id", nil
 	}
@@ -192,7 +192,7 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 }
 
 func GetOAuthToken(grantType string, clientId string, clientSecret string, code string) *TokenWrapper {
-	application := getApplicationByClientId(clientId)
+	application := GetApplicationByClientId(clientId)
 	if application == nil {
 		return &TokenWrapper{
 			AccessToken: "error: invalid client_id",

--- a/routers/authz_filter.go
+++ b/routers/authz_filter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/astaxie/beego/context"
 	"github.com/casdoor/casdoor/authz"
 	"github.com/casdoor/casdoor/controllers"
+	"github.com/casdoor/casdoor/object"
 	"github.com/casdoor/casdoor/util"
 )
 
@@ -41,6 +42,22 @@ func getUsername(ctx *context.Context) (username string) {
 	// bug in Beego: this call will panic when file session store is empty
 	// so we catch the panic
 	username = ctx.Input.Session("username").(string)
+
+	if len(username) == 0 {
+		query := ctx.Request.URL.RawQuery
+		clientId := parseQuery(query, "clientId")
+		clientSecret := parseQuery(query, "clientSecret")
+		if len(clientId) == 0 || len(clientSecret) == 0 {
+			return
+		}
+
+		app := object.GetApplicationByClientId(clientId)
+		if app == nil || app.ClientSecret != clientSecret {
+			return
+		}
+		return "built-in/service"
+	}
+
 	return
 }
 


### PR DESCRIPTION
If there is a client id and a client secret in URL, Casdoor will treat this request as `built-in/service`'s.