### PR TITLE
fix: <Link> to <a> and table key

### DIFF
--- a/web/src/UrlTable.js
+++ b/web/src/UrlTable.js
@@ -95,7 +95,7 @@ class UrlTable extends React.Component {
     ];
 
     return (
-      <Table rowKey="id" columns={columns} dataSource={table.map(row => ({id: row}))} size="middle" bordered pagination={{pageSize: 100}}
+      <Table rowKey="index" columns={columns} dataSource={table.map((row, i) => ({id: row, index: i}))} size="middle" bordered pagination={{pageSize: 100}}
              title={() => (
                <div>
                  {this.props.title}&nbsp;&nbsp;&nbsp;&nbsp;

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -194,13 +194,11 @@ class LoginPage extends React.Component {
                 {i18next.t("login:Auto login")}
               </Checkbox>
             </Form.Item>
-            <div style={{float: "right"}} onClick={() => {
+            <a style={{float: "right"}} onClick={() => {
               Setting.goToForget(this, application);
             }}>
-              <a>
-                {i18next.t("login:Forgot password?")}
-              </a>
-            </div>
+              {i18next.t("login:Forgot password?")}
+            </a>
           </Form.Item>
           <Form.Item>
             <Button
@@ -215,11 +213,11 @@ class LoginPage extends React.Component {
               !application.enableSignUp ? null : (
                 <div style={{float: "right"}}>
                   {i18next.t("login:No account yet?")}&nbsp;
-                  <Link onClick={() => {
+                  <a onClick={() => {
                     Setting.goToSignup(this, application);
                   }}>
                     {i18next.t("login:sign up now")}
-                  </Link>
+                  </a>
                 </div>
               )
             }
@@ -257,11 +255,11 @@ class LoginPage extends React.Component {
                 <br/>
                 <div style={{float: "right"}}>
                   {i18next.t("login:No account yet?")}&nbsp;
-                  <Link onClick={() => {
+                  <a onClick={() => {
                     Setting.goToSignup(this, application);
                   }}>
                     {i18next.t("login:sign up now")}
-                  </Link>
+                  </a>
                 </div>
               </div>
             )


### PR DESCRIPTION
1. Replace `<Link>` to `<a>` because it does not use prop `to` at `LoginPage`
2. Use `index` as key at `UrlTable`

Signed-off-by: WindSpirit <simon343riley@gmail.com>