### PR TITLE
feat: allow user signup with oauth

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -50,6 +50,12 @@ type RequestForm struct {
 	EmailCode   string `json:"emailCode"`
 	PhoneCode   string `json:"phoneCode"`
 	PhonePrefix string `json:"phonePrefix"`
+
+	Github   string `json:"github"`
+	Google   string `json:"google"`
+	Qq       string `json:"qq"`
+	Wechat   string `json:"wechat"`
+	Facebook string `json:"facebook"`
 }
 
 type Response struct {
@@ -132,6 +138,11 @@ func (c *ApiController) Signup() {
 			IsAdmin:       false,
 			IsGlobalAdmin: false,
 			IsForbidden:   false,
+			Github:        form.Github,
+			Google:        form.Google,
+			QQ:            form.Qq,
+			WeChat:        form.Wechat,
+			Facebook:      form.Facebook,
 		}
 		object.AddUser(user)
 

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -218,8 +218,12 @@ func (c *ApiController) Login() {
 		}
 
 		if form.Method == "signup" {
-			user := object.GetUserByField(application.Organization, provider.Type, userInfo.Id)
-			if user == nil {
+			var user *object.User
+			if len(userInfo.Id) > 0 {
+				user = object.GetUserByField(application.Organization, provider.Type, userInfo.Id)
+			}
+
+			if user == nil && len(userInfo.Username) > 0 {
 				user = object.GetUserByField(application.Organization, provider.Type, userInfo.Username)
 			}
 
@@ -241,14 +245,20 @@ func (c *ApiController) Login() {
 				//
 				//	object.LinkUserAccount(userId, provider.Type, userInfo.Id)
 				//}
+				var userProviderId string
+				if len(userInfo.Id) > 0 {
+					userProviderId = userInfo.Id
+				} else {
+					userProviderId = userInfo.Username
+				}
 
 				if !application.EnableSignUp {
-					resp = &Response{Status: "error", Msg: fmt.Sprintf("The account for provider: %s and username: %s does not exist and is not allowed to sign up as new account, please contact your IT support", provider.Type, userInfo.Username)}
+					resp = &Response{Status: "error", Msg: fmt.Sprintf("The account for provider: %s and username: %s does not exist and is not allowed to sign up as new account, please contact your IT support", provider.Type, userProviderId)}
 					c.Data["json"] = resp
 					c.ServeJSON()
 					return
 				} else {
-					resp = &Response{Status: "error", Msg: fmt.Sprintf("The account for provider: %s and username: %s does not exist, please create an account first", provider.Type, userInfo.Username)}
+					resp = &Response{Status: "error", Msg: fmt.Sprintf("The account for provider: %s and username: %s does not exist, please create an account first", provider.Type, userProviderId), Data: provider.Type, Data2: userProviderId}
 					c.Data["json"] = resp
 					c.ServeJSON()
 					return

--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -70,8 +70,8 @@ export function goToLink(link) {
   window.location.href = link;
 }
 
-export function goToLinkSoft(ths, link) {
-  ths.props.history.push(link);
+export function goToLinkSoft(ths, link, state = {}) {
+  ths.props.history.push({pathname: link, state: state});
 }
 
 export function showMessage(type, text) {

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -26,6 +26,8 @@ class AuthCallback extends React.Component {
     this.state = {
       classes: props,
       msg: null,
+      providerType: null,
+      providerId: null
     };
   }
 
@@ -74,6 +76,7 @@ class AuthCallback extends React.Component {
     const applicationName = innerParams.get("application");
     const providerName = innerParams.get("provider");
     const method = innerParams.get("method");
+    const organization = innerParams.get("organization");
 
     let redirectUri = `${window.location.origin}/callback`;
 
@@ -107,6 +110,9 @@ class AuthCallback extends React.Component {
         } else {
           this.setState({
             msg: res.msg,
+            providerType: res.data,
+            providerId: res.data2,
+            organization: organization
           });
         }
       });
@@ -119,7 +125,7 @@ class AuthCallback extends React.Component {
           (this.state.msg === null) ? (
             <Spin size="large" tip="Signing in..." style={{paddingTop: "10%"}} />
           ) : (
-            Util.renderMessageLarge(this, this.state.msg)
+            Util.renderMessageLarge(this, this.state.msg, {type: this.state.providerType, id: this.state.providerId, org: this.state.organization})
           )
         }
       </div>

--- a/web/src/auth/Provider.js
+++ b/web/src/auth/Provider.js
@@ -54,7 +54,7 @@ export function getAuthUrl(application, provider, method) {
   }
 
   const redirectUri = `${window.location.origin}/callback`;
-  const state = Util.getQueryParamsToState(application.name, provider.name, method);
+  const state = Util.getQueryParamsToState(application.name, provider.name, method, application.organization);
   if (provider.type === "Google") {
     return `${GoogleAuthUri}?client_id=${provider.clientId}&redirect_uri=${redirectUri}&scope=${GoogleAuthScope}&response_type=code&state=${state}`;
   } else if (provider.type === "GitHub") {

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -103,6 +103,8 @@ class SignupPage extends React.Component {
 
   onFinish(values) {
     values.phonePrefix = this.state.application?.organizationObj.phonePrefix;
+    values[this.props.location.state.type] = this.props.location.state.id;
+    values.organization = this.props.location.state.org;
     AuthBackend.signup(values)
       .then((res) => {
         if (res.status === 'ok') {

--- a/web/src/auth/Util.js
+++ b/web/src/auth/Util.js
@@ -46,7 +46,7 @@ export function renderMessage(msg) {
   }
 }
 
-export function renderMessageLarge(ths, msg) {
+export function renderMessageLarge(ths, msg, param = {}) {
   if (msg !== null) {
     return (
       <div style={{display: "inline"}}>
@@ -58,7 +58,7 @@ export function renderMessageLarge(ths, msg) {
             <Button key="home" onClick={() => Setting.goToLinkSoft(ths, "/")}>
               Home
             </Button>,
-            <Button type="primary" key="signup" onClick={() => Setting.goToLinkSoft(ths, "/signup")}>
+            <Button type="primary" key="signup" onClick={() => Setting.goToLinkSoft(ths, "/signup", param)}>
               Sign Up
             </Button>,
           ]}
@@ -91,9 +91,9 @@ export function getOAuthGetParameters(params) {
   }
 }
 
-export function getQueryParamsToState(applicationName, providerName, method) {
+export function getQueryParamsToState(applicationName, providerName, method, organization) {
   let query = window.location.search;
-  query = `${query}&application=${applicationName}&provider=${providerName}&method=${method}`;
+  query = `${query}&application=${applicationName}&provider=${providerName}&method=${method}&organization=${organization}`;
   if (method === "link") {
     query = `${query}&from=${window.location.pathname}`;
   }


### PR DESCRIPTION
1. Allow user sign up with OAuth account
2. Fix that `GetUserByField(org, providerType, providerId)` if `providerId` is empty, may return a wrong user

Deployed at: https://casdoor.leviatan.cn
But this site does not have phone verify so user cannot signup. 

I test this pr in local machine by disable all verify, user can successful signup with OAuth account:

![image](https://user-images.githubusercontent.com/24910914/121113992-8f746280-c845-11eb-95a8-99531069878e.png)


Signed-off-by: WindSpirit <simon343riley@gmail.com>