### PR TITLE
fix: limit token display length at token page

### DIFF
--- a/web/src/Setting.js
+++ b/web/src/Setting.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {message} from "antd";
+import {message, Tooltip} from "antd";
 import React from "react";
 import {isMobile as isMobileDevice} from "react-device-detect";
 import "./i18n";
@@ -207,15 +207,20 @@ export function changeLanguage(language) {
   window.location.reload(true);
 }
 
-export function getClickable(text) {
+export function getClickable(text, display) {
+  if (!display) {
+    display = text;
+  }
   return (
     // eslint-disable-next-line jsx-a11y/anchor-is-valid
-    <a onClick={() => {
-      copy(text);
-      showMessage("success", `Copied to clipboard`);
-    }}>
-      {text}
-    </a>
+    <Tooltip placement="top" title={i18next.t("general:Click to copy to clipboard")}>
+      <a onClick={() => {
+        copy(text);
+        showMessage("success", `Copied to clipboard`);
+      }}>
+        {display}
+      </a>
+    </Tooltip>
   )
 }
 

--- a/web/src/TokenListPage.js
+++ b/web/src/TokenListPage.js
@@ -36,6 +36,9 @@ class TokenListPage extends React.Component {
   getTokens() {
     TokenBackend.getTokens("admin")
       .then((res) => {
+        res.forEach((token) => {
+          token.tokenAbs = token.accessToken.substr(0,20)
+        })
         this.setState({
           tokens: res,
         });
@@ -158,19 +161,20 @@ class TokenListPage extends React.Component {
         key: 'code',
         // width: '150px',
         sorter: (a, b) => a.code.localeCompare(b.code),
+        ellipsis: true,
         render: (text, record, index) => {
           return Setting.getClickable(text);
         }
       },
       {
         title: i18next.t("token:Access token"),
-        dataIndex: 'accessToken',
-        key: 'accessToken',
+        dataIndex: 'tokenAbs',
+        key: 'tokenAbs',
         // width: '150px',
         sorter: (a, b) => a.accessToken.localeCompare(b.accessToken),
         ellipsis: true,
         render: (text, record, index) => {
-          return Setting.getClickable(text);
+          return Setting.getClickable(record.accessToken, text);
         }
       },
       {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -33,7 +33,8 @@
     "Applications that requires authentication": "Applications that requires authentication",
     "Swagger": "Swagger",
     "Phone Prefix": "Phone Prefix",
-    "Enter the code": "Enter the code"
+    "Enter the code": "Enter the code",
+    "Click to copy to clipboard": "Click to copy to clipboard"
   },
   "signup":
   {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -33,7 +33,8 @@
     "Applications that requires authentication": "需要鉴权的应用",
     "Swagger": "API总览",
     "Phone Prefix": "手机号前缀",
-    "Enter the code": "输入验证码"
+    "Enter the code": "输入验证码",
+    "Click to copy to clipboard": "点击以复制到剪切板"
   },
   "signup":
   {


### PR DESCRIPTION
1. Token string is too long caused performance low, so limit it to 20 characters only for display
2. Add `Tooltip` for `getClickable()` function
3. Add param `display` for `getClickable()`, what is it used for display text is different from the text you want to copy
4. fixed `Access token` row cannot be hidden if the browser width too small

Signed-off-by: WindSpiritSR <simon343riley@gmail.com>