### PR TITLE
feat: Allow the user to sign up with OAuth

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -121,8 +121,8 @@ func (c *ApiController) Signup() {
 		if form.WithProvider {
 			user := &object.User{
 				Owner:       form.Organization,
-				Name:        form.Username,
-				DisplayName: form.Name,
+				Name:        strings.ReplaceAll(strings.ToLower(form.Username), " ", "_"),
+				DisplayName: form.Username,
 				Avatar:      form.Avatar,
 				Password:    form.Password,
 				Email:       form.Email,
@@ -137,7 +137,7 @@ func (c *ApiController) Signup() {
 			object.DisableVerificationCode(form.Email)
 			object.DisableVerificationCode(checkPhone)
 			util.LogInfo(c.Ctx, "API: [%s] is signed up as new user", userId)
-			resp = Response{Status: "ok", Msg: "", Data: userId}
+			resp = Response{Status: "ok", Msg: "", Data: userId, Data2: object.User{Name: user.DisplayName, Owner: user.Owner}}
 		} else {
 			resp = Response{Status: "error", Msg: msg, Data: ""}
 		}

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -259,6 +259,9 @@ func (c *ApiController) Login() {
 
 				if !providerItem.CanSignUp {
 					resp = &Response{Status: "error", Msg: fmt.Sprintf("The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account via %s, please use another way to sign up", provider.Type, userInfo.Username, userInfo.DisplayName, provider.Type)}
+					c.Data["json"] = resp
+					c.ServeJSON()
+					return
 				}
 
 				// sign up via OAuth

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -100,7 +100,7 @@ class AuthCallback extends React.Component {
           } else if (responseType === "code") {
             const code = res.data;
             const userInfo = res.data2;
-            //If result userId, redirect to signuo with provider to complete user info
+            //If result userId, redirect to signup with provider to complete user info
             if (userInfo) {
               Setting.goToLink(`/signup/${applicationName}?redirect_url=${oAuthParams.redirectUri}&code=${code}&state=${oAuthParams.state}&owner=${userInfo.owner}&user=${userInfo.name}`);
             } else {

--- a/web/src/auth/AuthCallback.js
+++ b/web/src/auth/AuthCallback.js
@@ -19,6 +19,7 @@ import * as AuthBackend from "./AuthBackend";
 import * as Util from "./Util";
 import {authConfig} from "./Auth";
 import * as Setting from "../Setting";
+import * as Provider from "./Provider";
 
 class AuthCallback extends React.Component {
   constructor(props) {
@@ -98,7 +99,14 @@ class AuthCallback extends React.Component {
             Setting.goToLink("/");
           } else if (responseType === "code") {
             const code = res.data;
-            Setting.goToLink(`${oAuthParams.redirectUri}?code=${code}&state=${oAuthParams.state}`);
+            const userInfo = res.data2;
+            //If result userId, redirect to signuo with provider to complete user info
+            if (userInfo) {
+              Setting.goToLink(`/signup/${applicationName}?redirect_url=${oAuthParams.redirectUri}&code=${code}&state=${oAuthParams.state}&owner=${userInfo.owner}&user=${userInfo.name}`);
+            } else {
+              Setting.goToLink(`${oAuthParams.redirectUri}?code=${code}&state=${oAuthParams.state}`);
+            }
+
             // Util.showMessage("success", `Authorization code: ${res.data}`);
           } else if (responseType === "link") {
             const from = innerParams.get("from");

--- a/web/src/auth/SignupPage.js
+++ b/web/src/auth/SignupPage.js
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
-import {Link} from "react-router-dom";
-import {Form, Input, Checkbox, Button, Row, Col, Result} from 'antd';
+import React from "react";
+import { Link } from "react-router-dom";
+import { Form, Input, Checkbox, Button, Row, Col, Result, Avatar } from "antd";
 import * as Setting from "../Setting";
 import * as AuthBackend from "./AuthBackend";
 import i18next from "i18next";
 import * as Util from "./Util";
-import {authConfig} from "./Auth";
+import { authConfig } from "./Auth";
 import * as ApplicationBackend from "../backend/ApplicationBackend";
 import * as UserBackend from "../backend/UserBackend";
-import {CountDownInput} from "../component/CountDownInput";
+import { CountDownInput } from "../component/CountDownInput";
+import { getUser } from "../backend/UserBackend";
 
 const formItemLayout = {
   labelCol: {
@@ -59,14 +60,44 @@ const tailFormItemLayout = {
 class SignupPage extends React.Component {
   constructor(props) {
     super(props);
+
+    this.form = React.createRef();
+
+    const params = new URLSearchParams(this.props.location?.search);
+    const paramUser = params.get("user");
+    const paramOwner = params.get("owner");
+
+    let stateUrlParams = {
+      urlWithProvider: false,
+      user: "",
+      owner: "",
+    };
+
+    if (paramUser && paramOwner) {
+      stateUrlParams.urlWithProvider = true;
+      stateUrlParams.user = paramUser;
+      stateUrlParams.owner = paramOwner;
+    }
+
     this.state = {
       classes: props,
-      applicationName: props.match?.params.applicationName !== undefined ? props.match.params.applicationName : authConfig.appName,
+      applicationName:
+        props.match?.params.applicationName !== undefined
+          ? props.match.params.applicationName
+          : authConfig.appName,
       application: null,
       email: "",
       phone: "",
       emailCode: "",
-      phoneCode: ""
+      phoneCode: "",
+      provider: {
+        type: "",
+        user: "",
+        username: "",
+        email: "",
+        avatar: "",
+      },
+      urlParams: stateUrlParams,
     };
 
     this.form = React.createRef();
@@ -76,7 +107,10 @@ class SignupPage extends React.Component {
     if (this.state.applicationName !== undefined) {
       this.getApplication();
     } else {
-      Util.showMessage("error", `Unknown application name: ${this.state.applicationName}`);
+      Util.showMessage(
+        "error",
+        `Unknown application name: ${this.state.applicationName}`
+      );
     }
   }
 
@@ -112,9 +146,13 @@ class SignupPage extends React.Component {
   onFinish(values) {
     const application = this.getApplicationObj();
     values.phonePrefix = application.organizationObj.phonePrefix;
+    values.organization = application.organization;
+    values.application = application.name;
+    values.withProvider = this.state.urlParams.urlWithProvider;
+    values.avatar = this.state.provider.avatar;
     AuthBackend.signup(values)
       .then((res) => {
-        if (res.status === 'ok') {
+        if (res.status === "ok") {
           Setting.goToLinkSoft(this, this.getResultPath(application));
         } else {
           Setting.showMessage("error", i18next.t(`signup:${res.msg}`));
@@ -134,17 +172,34 @@ class SignupPage extends React.Component {
           title="Sign Up Error"
           subTitle={"The application does not allow to sign up new account"}
           extra={[
-            <Link onClick={() => {
-              Setting.goToLogin(this, application);
-            }}>
+            <Link
+              onClick={() => {
+                Setting.goToLogin(this, application);
+              }}
+            >
               <Button type="primary" key="signin">
                 Sign In
               </Button>
-            </Link>
+            </Link>,
           ]}
-        >
-        </Result>
-      )
+        ></Result>
+      );
+    }
+
+    let providerItem;
+    if (this.state.urlParams.urlWithProvider) {
+      providerItem = (
+        <Form.Item label={this.state.provider.type}>
+          <div>
+            <Avatar
+              size={40}
+              src={this.state.provider.avatar}
+              alt={this.state.provider.user}
+            />
+            <span style={{ marginLeft: 10 }}>{this.state.provider.user}</span>
+          </div>
+        </Form.Item>
+      );
     }
 
     return (
@@ -153,36 +208,19 @@ class SignupPage extends React.Component {
         ref={this.form}
         name="signup"
         onFinish={(values) => this.onFinish(values)}
-        onFinishFailed={(errorInfo) => this.onFinishFailed(errorInfo.values, errorInfo.errorFields, errorInfo.outOfDate)}
+        onFinishFailed={(errorInfo) => this.onFinishFailed(
+            errorInfo.values,
+            errorInfo.errorFields,
+            errorInfo.outOfDate
+          )}
         initialValues={{
           application: application.name,
           organization: application.organization,
         }}
-        style={{width: !Setting.isMobile() ? "400px" : "250px"}}
+        style={{ width: !Setting.isMobile() ? "400px" : "250px" }}
         size="large"
       >
-        <Form.Item
-          style={{height: 0, visibility: "hidden"}}
-          name="application"
-          rules={[
-            {
-              required: true,
-              message: 'Please input your application!',
-            },
-          ]}
-        >
-        </Form.Item>
-        <Form.Item
-          style={{height: 0, visibility: "hidden"}}
-          name="organization"
-          rules={[
-            {
-              required: true,
-              message: 'Please input your organization!',
-            },
-          ]}
-        >
-        </Form.Item>
+        {providerItem}
         <Form.Item
           name="username"
           label={i18next.t("signup:Username")}
@@ -227,7 +265,7 @@ class SignupPage extends React.Component {
           label={i18next.t("general:Email")}
           rules={[
             {
-              type: 'email',
+              type: "email",
               message: i18next.t("signup:The input is not valid Email!"),
             },
             {
@@ -236,20 +274,28 @@ class SignupPage extends React.Component {
             },
           ]}
         >
-          <Input onChange={e => this.setState({email: e.target.value})} />
+          <Input onChange={(e) => this.setState({ email: e.target.value })} />
         </Form.Item>
         <Form.Item
           name="emailCode"
           label={i18next.t("signup:email code")}
-          rules={[{
-            required: true,
-            message: i18next.t("signup:Please input your verification code!"),
-          }]}
+          rules={[
+            {
+              required: true,
+              message: i18next.t("signup:Please input your verification code!"),
+            },
+          ]}
         >
           <CountDownInput
             defaultButtonText={i18next.t("signup:send code")}
             onButtonClick={UserBackend.sendCode}
-            onButtonClickArgs={[this.state.email, "email", application?.organizationObj.owner + "/" + application?.organizationObj.name]}
+            onButtonClickArgs={[
+              this.state.email,
+              "email",
+              application?.organizationObj.owner +
+                "/" +
+                application?.organizationObj.name,
+            ]}
             coolDownTime={60}
           />
         </Form.Item>
@@ -269,7 +315,7 @@ class SignupPage extends React.Component {
         <Form.Item
           name="confirm"
           label={i18next.t("signup:Confirm")}
-          dependencies={['password']}
+          dependencies={["password"]}
           hasFeedback
           rules={[
             {
@@ -278,11 +324,15 @@ class SignupPage extends React.Component {
             },
             ({ getFieldValue }) => ({
               validator(rule, value) {
-                if (!value || getFieldValue('password') === value) {
+                if (!value || getFieldValue("password") === value) {
                   return Promise.resolve();
                 }
 
-                return Promise.reject(i18next.t("signup:Your confirmed password is inconsistent with the password!"));
+                return Promise.reject(
+                  i18next.t(
+                    "signup:Your confirmed password is inconsistent with the password!"
+                  )
+                );
               },
             }),
           ]}
@@ -301,10 +351,10 @@ class SignupPage extends React.Component {
         >
           <Input
             style={{
-              width: '100%',
+              width: "100%",
             }}
             addonBefore={`+${this.state.application?.organizationObj.phonePrefix}`}
-            onChange={e => this.setState({phone: e.target.value})}
+            onChange={(e) => this.setState({ phone: e.target.value })}
           />
         </Form.Item>
         <Form.Item
@@ -313,23 +363,33 @@ class SignupPage extends React.Component {
           rules={[
             {
               required: true,
-              message: i18next.t("signup:Please input your phone verification code!"),
+              message: i18next.t(
+                "signup:Please input your phone verification code!"
+              ),
             },
           ]}
         >
           <CountDownInput
             defaultButtonText={i18next.t("signup:send code")}
             onButtonClick={UserBackend.sendCode}
-            onButtonClickArgs={[this.state.phone, "phone", application.organizationObj.owner + "/" + application.organizationObj.name]}
+            onButtonClickArgs={[
+              this.state.phone,
+              "phone",
+              application.organizationObj.owner +
+                "/" +
+                application.organizationObj.name,
+            ]}
             coolDownTime={60}
           />
         </Form.Item>
-        <Form.Item name="agreement" valuePropName="checked" {...tailFormItemLayout}>
+        <Form.Item
+          name="agreement"
+          valuePropName="checked"
+          {...tailFormItemLayout}
+        >
           <Checkbox>
             {i18next.t("signup:Accept")}&nbsp;
-            <Link to={"/agreement"}>
-              {i18next.t("signup:Terms of Use")}
-            </Link>
+            <Link to={"/agreement"}>{i18next.t("signup:Terms of Use")}</Link>
           </Checkbox>
         </Form.Item>
         <Form.Item {...tailFormItemLayout}>
@@ -337,14 +397,58 @@ class SignupPage extends React.Component {
             {i18next.t("account:Sign Up")}
           </Button>
           &nbsp;&nbsp;{i18next.t("signup:Have account?")}&nbsp;
-          <Link onClick={() => {
-            Setting.goToLogin(this, application);
-          }}>
+          <Link
+            onClick={() => {
+              Setting.goToLogin(this, application);
+            }}>
             {i18next.t("signup:sign in now")}
           </Link>
         </Form.Item>
       </Form>
-    )
+    );
+  }
+
+  componentWillReceiveProps(nextProps, nextContext) {
+    if (this.state.urlParams.urlWithProvider) {
+      getUser(this.state.urlParams.owner, this.state.urlParams.user).then(
+        (user) => {
+          this.form.current.setFieldsValue({
+            username: user.displayName.toLowerCase().replace(" ", "_"),
+            name: user.displayName,
+            email: user.email,
+          });
+
+          this.setState({
+            provider: {
+              type: this.getProviderFromUser(user),
+              user: user.displayName,
+              avatar: user.avatar,
+            },
+          });
+        }
+      );
+    }
+  }
+
+  getProviderFromUser(userInfo) {
+    const providerType = [
+      { key: "google", name: "Google" },
+      { key: "github", name: "GitHub" },
+      { key: "qq", name: "QQ" },
+      { key: "wechat", name: "WeChat" },
+      { key: "facebook", name: "Facebook" },
+      { key: "dingtalk", name: "DingTalk" },
+      { key: "weibo", name: "Weibo" },
+    ];
+
+    let providerName = "";
+
+    providerType.forEach((provider) => {
+      if (userInfo[provider.key]) {
+        providerName = provider.name;
+      }
+    });
+    return providerName;
   }
 
   render() {
@@ -357,22 +461,16 @@ class SignupPage extends React.Component {
       <div>
         &nbsp;
         <Row>
-          <Col span={24} style={{display: "flex", justifyContent:  "center"}} >
-            <div style={{marginTop: "10px", textAlign: "center"}}>
-              {
-                Setting.renderHelmet(application)
-              }
-              {
-                Setting.renderLogo(application)
-              }
-              {
-                this.renderForm(application)
-              }
+          <Col span={24} style={{ display: "flex", justifyContent: "center" }}>
+            <div style={{ marginTop: "10px", textAlign: "center" }}>
+              {Setting.renderHelmet(application)}
+              {Setting.renderLogo(application)}
+              {this.renderForm(application)}
             </div>
           </Col>
         </Row>
       </div>
-    )
+    );
   }
 }
 


### PR DESCRIPTION
Allow the user to sign up when he tries to use OAuth to login but there's no account linked to the OAuth

Deployed at: https://casdoor.leviatan.cn/login/oauth/authorize?client_id=00c5f3410de2ebf737e4&response_type=code&redirect_uri=https://www.leviatan.cn&scope=read&state=casdoor

I closed #102 by an incorrect operation, I fixed problems at this PR.

1. Reuesd signup page
2. I don't know why, but my email and SMS provider config doesn't work, so I closed the Verification Code check only on this test server, you can enter any character in the `email code` and `phone code` to pass the verification.
3. Reformat by IDE

![image](https://user-images.githubusercontent.com/24910914/121993051-628bf680-cdd5-11eb-85a7-4fd3a2e1bd50.png)

Signed-off-by: WindSpiritSR simon343riley@gmail.com