### PR TITLE
fix: go.mod module declaration.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/casdoor/casdoor
+module github.com/casbin/casdoor
 
 go 1.15
 


### PR DESCRIPTION
Solves issue #25, when you use go get, you get the following error because the module is not declared correctly.

```
go get: github.com/casbin/casdoor@none updating to
        github.com/casbin/casdoor@v0.0.0-20210720132906-66f36d780ad8: parsing go.mod:
        module declares its path as: github.com/casdoor/casdoor
                but was required as: github.com/casbin/casdoor
```