### PR TITLE
fix: use ReponseError to response error

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -82,7 +82,7 @@ func (c *ApiController) Signup() {
 	var resp Response
 
 	if c.GetSessionUsername() != "" {
-		c.ResponseErrorWithData("Please sign out first before signing up", c.GetSessionUsername())
+		c.ResponseError("Please sign out first before signing up", c.GetSessionUsername())
 		return
 	}
 
@@ -211,9 +211,7 @@ func (c *ApiController) GetAccount() {
 
 	user := object.GetUser(userId)
 	if user == nil {
-		resp := Response{Status: "error", Msg: fmt.Sprintf("The user: %s doesn't exist", userId)}
-		c.Data["json"] = resp
-		c.ServeJSON()
+		c.ResponseError(fmt.Sprintf("The user: %s doesn't exist", userId))
 		return
 	}
 
@@ -245,18 +243,14 @@ func (c *ApiController) UploadAvatar() {
 	avatarBase64 := c.Ctx.Request.Form.Get("avatarfile")
 	index := strings.Index(avatarBase64, ",")
 	if index < 0 || avatarBase64[0:index] != "data:image/png;base64" {
-		resp = Response{Status: "error", Msg: "File encoding error"}
-		c.Data["json"] = resp
-		c.ServeJSON()
+		c.ResponseError("File encoding error")
 		return
 	}
 
 	dist, _ := base64.StdEncoding.DecodeString(avatarBase64[index+1:])
 	msg := object.UploadAvatar(provider, user.GetId(), dist)
 	if msg != "" {
-		resp = Response{Status: "error", Msg: msg}
-		c.Data["json"] = resp
-		c.ServeJSON()
+		c.ResponseError(msg)
 		return
 	}
 	user.Avatar = fmt.Sprintf("%s%s.png?time=%s", object.GetAvatarPath(provider), user.GetId(), util.GetCurrentUnixTime())

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -100,6 +100,14 @@ func (c *ApiController) GetApplicationLogin() {
 	c.ServeJSON()
 }
 
+func setHttpClient(idProvider idp.IdProvider, providerType string) {
+	if providerType == "GitHub" || providerType == "Google" || providerType == "Facebook" || providerType == "LinkedIn" {
+		idProvider.SetHttpClient(proxyHttpClient)
+	} else {
+		idProvider.SetHttpClient(defaultHttpClient)
+	}
+}
+
 // @Title Login
 // @Description login
 // @Param   oAuthParams     query    string  true        "oAuth parameters"
@@ -213,7 +221,7 @@ func (c *ApiController) Login() {
 			return
 		}
 
-		idProvider.SetHttpClient(httpClient)
+		setHttpClient(idProvider, provider.Type)
 
 		if form.State != beego.AppConfig.String("authState") && form.State != application.Name {
 			resp = &Response{Status: "error", Msg: fmt.Sprintf("state expected: \"%s\", but got: \"%s\"", beego.AppConfig.String("authState"), form.State)}

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -27,21 +27,13 @@ import (
 	"github.com/casbin/casdoor/util"
 )
 
-func codeToResponse(code *object.Code) *Response {
-	if code.Code == "" {
-		return &Response{Status: "error", Msg: code.Message, Data: code.Code}
-	} else {
-		return &Response{Status: "ok", Msg: "", Data: code.Code}
-	}
-}
-
-func (c *ApiController) HandleLoggedIn(application *object.Application, user *object.User, form *RequestForm) *Response {
+func (c *ApiController) HandleLoggedIn(application *object.Application, user *object.User, form *RequestForm) {
 	userId := user.GetId()
-	resp := &Response{}
 	if form.Type == ResponseTypeLogin {
 		c.SetSessionUsername(userId)
 		util.LogInfo(c.Ctx, "API: [%s] signed in", userId)
-		resp = &Response{Status: "ok", Msg: "", Data: userId}
+		c.Data["json"] = Response{Status: "ok", Msg: "", Data: userId}
+		c.ServeJSON()
 	} else if form.Type == ResponseTypeCode {
 		clientId := c.Input().Get("clientId")
 		responseType := c.Input().Get("responseType")
@@ -50,26 +42,31 @@ func (c *ApiController) HandleLoggedIn(application *object.Application, user *ob
 		state := c.Input().Get("state")
 
 		code := object.GetOAuthCode(userId, clientId, responseType, redirectUri, scope, state)
-		resp = codeToResponse(code)
+		if code.Code == "" {
+			c.ResponseError(code.Message, code.Code)
+			return
+		} else {
+			c.Data["json"] = Response{Status: "ok", Msg: "", Data: code.Code}
+			c.ServeJSON()
+		}
 
 		if application.HasPromptPage() {
 			// The prompt page needs the user to be signed in
 			c.SetSessionUsername(userId)
 		}
 	} else {
-		resp = &Response{Status: "error", Msg: fmt.Sprintf("Unknown response type: %s", form.Type)}
+		c.ResponseError(fmt.Sprintf("Unknown response type: %s", form.Type))
+		return
 	}
 
 	// if user did not check auto signin
-	if resp.Status == "ok" && !form.AutoSignin {
+	if !form.AutoSignin {
 		timestamp := time.Now().Unix()
 		timestamp += 3600 * 24
 		c.SetSessionData(&SessionData{
 			ExpireTime: timestamp,
 		})
 	}
-
-	return resp
 }
 
 // @Title GetApplicationLogin
@@ -82,8 +79,6 @@ func (c *ApiController) HandleLoggedIn(application *object.Application, user *ob
 // @Success 200 {object} controllers.api_controller.Response The Response object
 // @router /update-application [get]
 func (c *ApiController) GetApplicationLogin() {
-	var resp Response
-
 	clientId := c.Input().Get("clientId")
 	responseType := c.Input().Get("responseType")
 	redirectUri := c.Input().Get("redirectUri")
@@ -92,11 +87,11 @@ func (c *ApiController) GetApplicationLogin() {
 
 	msg, application := object.CheckOAuthLogin(clientId, responseType, redirectUri, scope, state)
 	if msg != "" {
-		resp = Response{Status: "error", Msg: msg, Data: application}
-	} else {
-		resp = Response{Status: "ok", Msg: "", Data: application}
+		c.ResponseError(msg, application)
+		return
 	}
-	c.Data["json"] = resp
+
+	c.Data["json"] = Response{Status: "ok", Msg: "", Data: application}
 	c.ServeJSON()
 }
 
@@ -115,22 +110,17 @@ func setHttpClient(idProvider idp.IdProvider, providerType string) {
 // @Success 200 {object} controllers.api_controller.Response The Response object
 // @router /login [post]
 func (c *ApiController) Login() {
-	resp := &Response{Status: "null", Msg: ""}
 	var form RequestForm
 	err := json.Unmarshal(c.Ctx.Input.RequestBody, &form)
 	if err != nil {
-		resp = &Response{Status: "error", Msg: err.Error()}
-		c.Data["json"] = resp
-		c.ServeJSON()
+		c.ResponseError(err.Error())
 		return
 	}
 
 	if form.Username != "" {
 		if form.Type == ResponseTypeLogin {
 			if c.GetSessionUsername() != "" {
-				resp = &Response{Status: "error", Msg: "Please log out first before signing in", Data: c.GetSessionUsername()}
-				c.Data["json"] = resp
-				c.ServeJSON()
+				c.ResponseError("Please log out first before signing in", c.GetSessionUsername())
 				return
 			}
 		}
@@ -196,10 +186,11 @@ func (c *ApiController) Login() {
 		}
 
 		if msg != "" {
-			resp = &Response{Status: "error", Msg: msg, Data: ""}
+			c.ResponseError(msg)
+			return
 		} else {
 			application := object.GetApplication(fmt.Sprintf("admin/%s", form.Application))
-			resp = c.HandleLoggedIn(application, user, &form)
+			c.HandleLoggedIn(application, user, &form)
 
 			record := util.Records(c.Ctx)
 			record.Organization = application.Organization
@@ -215,42 +206,32 @@ func (c *ApiController) Login() {
 
 		idProvider := idp.GetIdProvider(provider.Type, provider.ClientId, provider.ClientSecret, form.RedirectUri)
 		if idProvider == nil {
-			resp = &Response{Status: "error", Msg: fmt.Sprintf("provider: %s does not exist", provider.Type)}
-			c.Data["json"] = resp
-			c.ServeJSON()
+			c.ResponseError(fmt.Sprintf("provider: %s does not exist", provider.Type))
 			return
 		}
 
 		setHttpClient(idProvider, provider.Type)
 
 		if form.State != beego.AppConfig.String("authState") && form.State != application.Name {
-			resp = &Response{Status: "error", Msg: fmt.Sprintf("state expected: \"%s\", but got: \"%s\"", beego.AppConfig.String("authState"), form.State)}
-			c.Data["json"] = resp
-			c.ServeJSON()
+			c.ResponseError(fmt.Sprintf("state expected: \"%s\", but got: \"%s\"", beego.AppConfig.String("authState"), form.State))
 			return
 		}
 
 		// https://github.com/golang/oauth2/issues/123#issuecomment-103715338
 		token, err := idProvider.GetToken(form.Code)
 		if err != nil {
-			resp = &Response{Status: "error", Msg: err.Error()}
-			c.Data["json"] = resp
-			c.ServeJSON()
+			c.ResponseError(err.Error())
 			return
 		}
 
 		if !token.Valid() {
-			resp = &Response{Status: "error", Msg: "Invalid token"}
-			c.Data["json"] = resp
-			c.ServeJSON()
+			c.ResponseError("Invalid token")
 			return
 		}
 
 		userInfo, err := idProvider.GetUserInfo(token)
 		if err != nil {
-			resp = &Response{Status: "error", Msg: fmt.Sprintf("Failed to login in: %s", err.Error())}
-			c.Data["json"] = resp
-			c.ServeJSON()
+			c.ResponseError(fmt.Sprintf("Failed to login in: %s", err.Error()))
 			return
 		}
 
@@ -276,7 +257,7 @@ func (c *ApiController) Login() {
 				//	object.LinkMemberAccount(userId, "avatar", avatar)
 				//}
 
-				resp = c.HandleLoggedIn(application, user, &form)
+				c.HandleLoggedIn(application, user, &form)
 
 				record := util.Records(c.Ctx)
 				record.Organization = application.Organization
@@ -286,16 +267,12 @@ func (c *ApiController) Login() {
 			} else {
 				// Sign up via OAuth
 				if !application.EnableSignUp {
-					resp = &Response{Status: "error", Msg: fmt.Sprintf("The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support", provider.Type, userInfo.Username, userInfo.DisplayName)}
-					c.Data["json"] = resp
-					c.ServeJSON()
+					c.ResponseError(fmt.Sprintf("The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account, please contact your IT support", provider.Type, userInfo.Username, userInfo.DisplayName))
 					return
 				}
 
 				if !providerItem.CanSignUp {
-					resp = &Response{Status: "error", Msg: fmt.Sprintf("The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account via %s, please use another way to sign up", provider.Type, userInfo.Username, userInfo.DisplayName, provider.Type)}
-					c.Data["json"] = resp
-					c.ServeJSON()
+					c.ResponseError(fmt.Sprintf("The account for provider: %s and username: %s (%s) does not exist and is not allowed to sign up as new account via %s, please use another way to sign up", provider.Type, userInfo.Username, userInfo.DisplayName, provider.Type))
 					return
 				}
 
@@ -324,7 +301,7 @@ func (c *ApiController) Login() {
 
 				object.LinkUserAccount(user, provider.Type, userInfo.Id)
 
-				resp = c.HandleLoggedIn(application, user, &form)
+				c.HandleLoggedIn(application, user, &form)
 
 				record := util.Records(c.Ctx)
 				record.Organization = application.Organization
@@ -336,9 +313,7 @@ func (c *ApiController) Login() {
 		} else { // form.Method != "signup"
 			userId := c.GetSessionUsername()
 			if userId == "" {
-				resp = &Response{Status: "error", Msg: "The account does not exist", Data: userInfo}
-				c.Data["json"] = resp
-				c.ServeJSON()
+				c.ResponseError("The account does not exist", userInfo)
 				return
 			}
 
@@ -347,9 +322,7 @@ func (c *ApiController) Login() {
 				oldUser = object.GetUserByField(application.Organization, provider.Type, userInfo.Username)
 			}
 			if oldUser != nil {
-				resp = &Response{Status: "error", Msg: fmt.Sprintf("The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)", provider.Type, userInfo.Username, userInfo.DisplayName, oldUser.Name, oldUser.DisplayName)}
-				c.Data["json"] = resp
-				c.ServeJSON()
+				c.ResponseError(fmt.Sprintf("The account for provider: %s and username: %s (%s) is already linked to another account: %s (%s)", provider.Type, userInfo.Username, userInfo.DisplayName, oldUser.Name, oldUser.DisplayName))
 				return
 			}
 
@@ -360,9 +333,12 @@ func (c *ApiController) Login() {
 
 			isLinked := object.LinkUserAccount(user, provider.Type, userInfo.Id)
 			if isLinked {
-				resp = &Response{Status: "ok", Msg: "", Data: isLinked}
+				c.Data["json"] = &Response{Status: "ok", Msg: "", Data: isLinked}
+				c.ServeJSON()
+				return
 			} else {
-				resp = &Response{Status: "error", Msg: "Failed to link user account", Data: isLinked}
+				c.ResponseError("Failed to link user account", isLinked)
+				return
 			}
 			//if len(object.GetMemberAvatar(userId)) == 0 {
 			//	avatar := UploadAvatarToStorage(tempUserAccount.AvatarUrl, userId)
@@ -373,6 +349,6 @@ func (c *ApiController) Login() {
 		panic("unknown authentication type (not password or provider), form = " + util.StructToJson(form))
 	}
 
-	c.Data["json"] = resp
+	c.Data["json"] = Response{Status: "null"}
 	c.ServeJSON()
 }

--- a/controllers/ldap.go
+++ b/controllers/ldap.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"encoding/json"
+
 	"github.com/casbin/casdoor/object"
 	"github.com/casbin/casdoor/util"
 )
@@ -55,15 +56,13 @@ func (c *ApiController) GetLdapUser() {
 
 	conn, err := object.GetLdapConn(ldapServer.Host, ldapServer.Port, ldapServer.Admin, ldapServer.Passwd)
 	if err != nil {
-		c.Data["json"] = Response{Status: "error", Msg: err.Error()}
-		c.ServeJSON()
+		c.ResponseError(err.Error())
 		return
 	}
 
 	//groupsMap, err := conn.GetLdapGroups(ldapServer.BaseDn)
 	//if err != nil {
-	//	c.Data["json"] = Response{Status: "error", Msg: err.Error()}
-	//	c.ServeJSON()
+	//	c.ResponseError(err.Error())
 	//	return
 	//}
 
@@ -76,8 +75,7 @@ func (c *ApiController) GetLdapUser() {
 
 	users, err := conn.GetLdapUsers(ldapServer.BaseDn)
 	if err != nil {
-		c.Data["json"] = Response{Status: "error", Msg: err.Error()}
-		c.ServeJSON()
+		c.ResponseError(err.Error())
 		return
 	}
 

--- a/controllers/link.go
+++ b/controllers/link.go
@@ -43,9 +43,7 @@ func (c *ApiController) Unlink() {
 	value := object.GetUserField(user, providerType)
 
 	if value == "" {
-		resp = Response{Status: "error", Msg: "Please link first", Data: value}
-		c.Data["json"] = resp
-		c.ServeJSON()
+		c.ResponseError("Please link first", value)
 		return
 	}
 

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -21,12 +21,17 @@ import (
 	"golang.org/x/net/proxy"
 )
 
-var httpClient *http.Client
+var defaultHttpClient *http.Client
+var proxyHttpClient *http.Client
 
 func InitHttpClient() {
+	// not use proxy
+	defaultHttpClient = http.DefaultClient
+
+	// use proxy
 	httpProxy := beego.AppConfig.String("httpProxy")
 	if httpProxy == "" {
-		httpClient = &http.Client{}
+		proxyHttpClient = &http.Client{}
 		return
 	}
 
@@ -37,11 +42,11 @@ func InitHttpClient() {
 	}
 
 	tr := &http.Transport{Dial: dialer.Dial}
-	httpClient = &http.Client{
+	proxyHttpClient = &http.Client{
 		Transport: tr,
 	}
 
-	//resp, err2 := httpClient.Get("https://google.com")
+	//resp, err2 := proxyHttpClient.Get("https://google.com")
 	//if err2 != nil {
 	//	panic(err2)
 	//}

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -67,17 +67,10 @@ func (c *ApiController) ResponseError(error string, data ...interface{}) {
 	c.ServeJSON()
 }
 
-func (c *ApiController) ResponseErrorWithData(error string, data interface{}) {
-	c.Data["json"] = Response{Status: "error", Msg: error, Data: data}
-	c.ServeJSON()
-}
-
 func (c *ApiController) RequireSignedIn() (string, bool) {
 	userId := c.GetSessionUsername()
 	if userId == "" {
-		resp := Response{Status: "error", Msg: "Please sign in first"}
-		c.Data["json"] = resp
-		c.ServeJSON()
+		c.ResponseError("Please sign in first")
 		return "", false
 	}
 	return userId, true

--- a/object/user.go
+++ b/object/user.go
@@ -56,7 +56,7 @@ type User struct {
 	Weibo    string `xorm:"weibo varchar(100)" json:"weibo"`
 	Gitee    string `xorm:"gitee varchar(100)" json:"gitee"`
 	LinkedIn string `xorm:"linkedin varchar(100)" json:"linkedin"`
-	WeCom    string `xorm:"wecom varchar(100)" json:"we_com"`
+	Wecom    string `xorm:"wecom varchar(100)" json:"wecom"`
 
 	Ldap       string            `xorm:"ldap varchar(100)" json:"ldap"`
 	Properties map[string]string `json:"properties"`


### PR DESCRIPTION
Fixed: https://github.com/casbin/casdoor/issues/212

Removed `ResponseErrorWithData`, and added a `data` array as optional parameters in `ResponseError` like this: 
```go
func (c *ApiController) ResponseError(error string, data ...interface{}) {
	resp := Response{Status: "error", Msg: error}
	switch len(data) {
	case 2:
		resp.Data2 = data[1]
		fallthrough
	case 1:
		resp.Data = data[0]
	}
	c.Data["json"] = resp
	c.ServeJSON()
}
```