### PR TITLE
fix: the time expired should be > time.Now().Unix()

### DIFF
--- a/controllers/base.go
+++ b/controllers/base.go
@@ -34,7 +34,7 @@ func (c *ApiController) GetSessionUsername() string {
 	sessionData := c.GetSessionData()
 	if sessionData != nil &&
 		sessionData.ExpireTime != 0 &&
-		sessionData.ExpireTime < time.Now().Unix() {
+		sessionData.ExpireTime > time.Now().Unix() {
 		c.SetSessionUsername("")
 		c.SetSessionData(nil)
 		return ""


### PR DESCRIPTION
fix: i think check the time expired should be > time.Now().Unix()