### PR TITLE
fix: hide meaningless params in record uri

### DIFF
--- a/object/record.go
+++ b/object/record.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"fmt"
 	"github.com/casbin/casdoor/util"
 )
 
@@ -24,8 +25,8 @@ type Records struct {
 }
 
 func AddRecord(record *util.Record) bool {
-	records := new(Records)
-	records.Record = *record
+	record.RequestUri = hideUriParams(record.RequestUri)
+	records := Records{Record: *record}
 
 	affected, err := adapter.Engine.Insert(records)
 	if err != nil {
@@ -33,6 +34,21 @@ func AddRecord(record *util.Record) bool {
 	}
 
 	return affected != 0
+}
+
+func hideUriParams(urlStr string) string {
+	hideKeys := []string{"accessToken", "clientSecret"}
+	params := util.GetUrlParams(urlStr)
+	paramsStr := "?"
+	for key, param := range params {
+		fmt.Println(param)
+		_, found := util.FindStrInSlice(&key, &hideKeys)
+		if found {
+			param = []string{"***"}
+		}
+		paramsStr = fmt.Sprintf("%s%s=%s&", paramsStr, key, param[0])
+	}
+	return fmt.Sprintf("%s%s", util.GetUrlPath(urlStr), paramsStr[:len(paramsStr)-1])
 }
 
 func GetRecordCount() int {

--- a/util/path.go
+++ b/util/path.go
@@ -42,3 +42,9 @@ func GetUrlHost(urlString string) string {
 	u, _ := url.Parse(urlString)
 	return fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 }
+
+func GetUrlParams(urlString string) map[string][]string {
+	u, _ := url.Parse(urlString)
+	q, _ := url.ParseQuery(u.RawQuery)
+	return q
+}

--- a/util/string.go
+++ b/util/string.go
@@ -65,6 +65,15 @@ func IsStrsEmpty(strs ...string) bool {
 	return false
 }
 
+func FindStrInSlice(str *string, slice *[]string) (int, bool) {
+	for i, item := range *slice {
+		if item == *str {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
 func GetMaxLenStr(strs ...string) string {
 	m := 0
 	i := 0


### PR DESCRIPTION
Deployed at: https://door.leviatan.cn/

Hide meaningless but secure related params in record uri

And fix the error that record uri too long like `accessToken`(access `account` from `Setting` in Header)

Signed-off-by: WindSpiritSR <simon343riley@gmail.com>