### PR TITLE
feat: ban npm to solve potential bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Casdoor provides two run modes, the difference is binary size and user prompt.
 Edit `conf/app.conf`, set `runmode=dev`. Firstly build front-end files:
 
 ```bash
-cd web/ && npm install && npm run start
+cd web/ && yarn && yarn run start
 ```
-*❗ A word of caution ❗: the `npm` commands above need a recommended system RAM of at least 4GB. It has a potential failure during building the files if your RAM is not sufficient.*
+*❗ A word of caution ❗: Casdoor's front-end is built using yarn. You should use `yarn` instead of `npm`. It has a potential failure during building the files if you use `npm`.*
 
 Then build back-end binary file, change directory to root(Relative to casdoor):
 
@@ -103,7 +103,7 @@ That's it! Try to visit http://127.0.0.1:7001/. :small_airplane:
 Edit `conf/app.conf`, set `runmode=prod`. Firstly build front-end files:
 
 ```bash
-cd web/ && npm install && npm run build
+cd web/ && yarn && yarn run build
 ```
 
 Then build back-end binary file, change directory to root(Relative to casdoor):

--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,8 @@
     "build": "craco build",
     "test": "craco test",
     "eject": "craco eject",
-    "crowdin:sync": "crowdin upload && crowdin download"
+    "crowdin:sync": "crowdin upload && crowdin download",
+    "preinstall": "npx use-yarn -m 'Please use yarn!'"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Fix: https://github.com/casbin/casdoor/issues/294

Casdoor's front-end is built using yarn. Using npm will cause potential bugs due to installing wrong version of dependencies, so we just ban it.

Use solution from: https://github.com/alexanderwallin/use-yarn-instead/issues/1#issuecomment-292564355