### PR TITLE
fix: log file permission

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 	beego.BConfig.WebConfig.Session.SessionCookieLifeTime = 3600 * 24 * 30
 	//beego.BConfig.WebConfig.Session.SessionCookieSameSite = http.SameSiteNoneMode
 
-	err := logs.SetLogger("file", `{"filename":"logs/casdoor.log","maxdays":99999}`)
+	err := logs.SetLogger("file", `{"filename":"logs/casdoor.log","maxdays":99999,"perm":"0770"}`)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
If perm is not set manually, `go run main.go` cannot even start when `umask=022` because of permission error.
https://github.com/beego/beego/issues/3751
https://github.com/beego/beego/pull/4043