### PR TITLE
fix: signup logic when email and phone not enabled

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -95,7 +95,7 @@ func (c *ApiController) Signup() {
 		return
 	}
 
-	if application.IsSignupItemEnabled("Email") {
+	if application.IsSignupItemVisible("Email") {
 		checkResult := object.CheckVerificationCode(form.Email, form.EmailCode)
 		if len(checkResult) != 0 {
 			c.ResponseError(fmt.Sprintf("Email%s", checkResult))
@@ -104,7 +104,7 @@ func (c *ApiController) Signup() {
 	}
 
 	var checkPhone string
-	if application.IsSignupItemEnabled("Phone") {
+	if application.IsSignupItemVisible("Phone") {
 		checkPhone = fmt.Sprintf("+%s%s", form.PhonePrefix, form.Phone)
 		checkResult := object.CheckVerificationCode(checkPhone, form.PhoneCode)
 		if len(checkResult) != 0 {


### PR DESCRIPTION
`IsSignupItemEnabled` fails to do what it should do. It just check the existence of an item in `application.SignupItems`. 
But the `SignupItems` will always have all the items, even those items which are not visible or required. So I use `IsSignupItemVisible` instead.
In fact, an item is **actually enabled** only if it is visible, so `IsSignupItemEnabled` is of no use. Can we just remove it?