### PR TITLE
refactor: display resources and swagger menu  for normal users

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -331,15 +331,14 @@ class App extends Component {
       );
     }
 
-    res.push(
-      <Menu.Item key="/resources">
-        <Link to="/resources">
-          {i18next.t("general:Resources")}
-        </Link>
-      </Menu.Item>
-    );
-
     if (Setting.isAdminUser(this.state.account)) {
+      res.push(
+        <Menu.Item key="/resources">
+          <Link to="/resources">
+            {i18next.t("general:Resources")}
+          </Link>
+        </Menu.Item>
+      );
       res.push(
         <Menu.Item key="/tokens">
           <Link to="/tokens">
@@ -354,15 +353,14 @@ class App extends Component {
           </Link>
         </Menu.Item>
       );
+      res.push(
+        <Menu.Item key="/swagger">
+          <a target="_blank" rel="noreferrer" href={Setting.isLocalhost ? `${Setting.ServerUrl}/swagger` : "/swagger"}>
+            {i18next.t("general:Swagger")}
+          </a>
+        </Menu.Item>
+      );
     }
-
-    res.push(
-      <Menu.Item key="/swagger">
-        <a target="_blank" rel="noreferrer" href={Setting.isLocalhost ? `${Setting.ServerUrl}/swagger` : "/swagger"}>
-          {i18next.t("general:Swagger")}
-        </a>
-      </Menu.Item>
-    );
 
     return res;
   }


### PR DESCRIPTION
I think there have no use to display resources and swagger menu.
They should only upload thing through avatar uploading or something administers allow.
And swagger is for developer, normal users needn't see it.