### PR TITLE
fix: save country code

### DIFF
--- a/web/src/SelectRegionBox.js
+++ b/web/src/SelectRegionBox.js
@@ -47,7 +47,7 @@ class SelectRegionBox extends React.Component {
           >
             {
                 Setting.CountryRegionData.map((item, index) => (
-                    <Option key={index} value={item.name} label={item.name} >
+                    <Option key={index} value={item.code} label={item.code} >
                         <img src={`${Setting.StaticBaseUrl}/flag-icons/${item.code}.svg`} alt={item.name} height={20} style={{marginRight: 10}}/>
                         {`${item.name} (${item.code})`}
                     </Option>

--- a/web/src/UserListPage.js
+++ b/web/src/UserListPage.js
@@ -116,6 +116,13 @@ class UserListPage extends React.Component {
   }
 
   renderTable(users) {
+    // transfer country code to name based on selected language
+    var countries = require("i18n-iso-countries");
+    countries.registerLocale(require("i18n-iso-countries/langs/" + i18next.language + ".json"));
+    for (var index in users) {
+      users[index].region = countries.getName(users[index].region, i18next.language, {select: "official"})
+    }
+
     const columns = [
       {
         title: i18next.t("general:Organization"),


### PR DESCRIPTION
With the update of #321, the data saved in different language interfaces are also in different languages. 
So I tend to save the country code and transfer it to the name when rendering.

![image](https://user-images.githubusercontent.com/33992371/141233253-691008c0-ebf3-4cf9-add2-e8e578245659.png)
![image](https://user-images.githubusercontent.com/33992371/141233274-e2a7411c-26ba-4df2-96d9-48f74701d542.png)


Signed-off-by: “seriouszyx” <seriouszyx@foxmail.com>