### PR TITLE
fix: fix incorrect issuer in id token of oidc

### DIFF
--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/astaxie/beego"
 	"github.com/golang-jwt/jwt/v4"
 )
 
@@ -42,7 +43,7 @@ func generateJwtToken(application *Application, user *User) (string, error) {
 	claims := Claims{
 		User: *user,
 		RegisteredClaims: jwt.RegisteredClaims{
-			Issuer:    "Casdoor",
+			Issuer:    beego.AppConfig.String("oidcOrigin"),
 			Subject:   user.Id,
 			Audience:  []string{application.ClientId},
 			ExpiresAt: jwt.NewNumericDate(expireTime),


### PR DESCRIPTION
fix: fix incorrect issuer in id token of oidc

This modification is proposed according to oidc protocol as well as on demand of users trying to use  casdoor  in oidc