### PR TITLE
fix: add id_token and support auth header

### DIFF
--- a/object/token.go
+++ b/object/token.go
@@ -15,6 +15,7 @@
 package object
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/casbin/casdoor/util"
@@ -44,6 +45,7 @@ type Token struct {
 
 type TokenWrapper struct {
 	AccessToken string `json:"access_token"`
+	IDToken     string `json:"id_token"`
 	TokenType   string `json:"token_type"`
 	ExpiresIn   int    `json:"expires_in"`
 	Scope       string `json:"scope"`
@@ -216,7 +218,7 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 	}
 }
 
-func GetOAuthToken(grantType string, clientId string, clientSecret string, code string) *TokenWrapper {
+func GetOAuthToken(grantType string, clientId string, clientSecret string, code string) (*TokenWrapper, error) {
 	application := GetApplicationByClientId(clientId)
 	if application == nil {
 		return &TokenWrapper{
@@ -224,7 +226,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
-		}
+		}, fmt.Errorf("error: invalid client_id")
 	}
 
 	if grantType != "authorization_code" {
@@ -233,7 +235,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
-		}
+		}, fmt.Errorf("error: grant_type should be \"authorization_code\"")
 	}
 
 	if code == "" {
@@ -242,7 +244,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
-		}
+		}, fmt.Errorf("error: code should not be empty")
 	}
 
 	token := getTokenByCode(code)
@@ -252,7 +254,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
-		}
+		}, fmt.Errorf("error: invalid code")
 	}
 
 	if application.Name != token.Application {
@@ -261,7 +263,7 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
-		}
+		}, fmt.Errorf("error: the token is for wrong application (client_id)")
 	}
 
 	if application.ClientSecret != clientSecret {
@@ -270,15 +272,16 @@ func GetOAuthToken(grantType string, clientId string, clientSecret string, code 
 			TokenType:   "",
 			ExpiresIn:   0,
 			Scope:       "",
-		}
+		}, fmt.Errorf("error: invalid client_secret")
 	}
 
 	tokenWrapper := &TokenWrapper{
 		AccessToken: token.AccessToken,
+		IDToken:     token.AccessToken,
 		TokenType:   token.TokenType,
 		ExpiresIn:   token.ExpiresIn,
 		Scope:       token.Scope,
 	}
 
-	return tokenWrapper
+	return tokenWrapper, nil
 }


### PR DESCRIPTION
This PR contains 2 fixes: 
1.  add an 'id_token' field in access_token according to oidc protocol
2. supporting read client_id and client_secret from Basic Authorization Header, and return 400 instead of 200 when we cannot give out access_token.
See  <https://code.google.com/p/goauth2/issues/detail?id=31>  for why we are doing this.

This is because that despite Oauth 2.0 (rfc 6749, section 4.1.3)has mentioned that client_id and client_secret should be put into post form when using 'authorization code grant' method, (which is exactly the way we use in casdoor), however there do exist a contradictory expression in the same doc (rfc 6749, section 2.3.1) which is "The authorization server MUST support the HTTP Basic authentication scheme for authenticating clients that were issued a client password", indicating that it's ok to pass client_id and client_secret in Basic Authorization Header. For example, google uses the former way but github, reddit uses the latter way. 

Due to this confusion, it is SUGGESTED (not STIPULATED) that oauth client should try both methods, and distinguishes whether the current method successes by http response code.(for example, go oauth library try auth header first, and if non-2xx is returned, they try post form).This is the reason why we are adding 400 code into controller.

Also ,to avoid unnecessary failures, it's proper for us to support both methods, so we add support to read client_id and client_secret from Basic Authorization Header. 
