### PR TITLE
fix: support using bearer token to access protected resources

### DIFF
--- a/controllers/util.go
+++ b/controllers/util.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/astaxie/beego"
 	"github.com/casbin/casdoor/object"
@@ -53,6 +54,14 @@ func (c *ApiController) ResponseError(error string, data ...interface{}) {
 
 // RequireSignedIn ...
 func (c *ApiController) RequireSignedIn() (string, bool) {
+	accessToken := strings.Split(c.Ctx.Request.Header.Get("Authorization"), " ")
+	if len(accessToken) > 1 {
+		claims, err := object.ParseJwtToken(accessToken[1])
+		if err == nil {
+			c.SetSessionUsername(fmt.Sprintf("%v/%v", claims.Owner, claims.Name))
+			c.SetSessionData(&SessionData{ExpireTime: claims.ExpiresAt.Unix()})
+		}
+	}
 	userId := c.GetSessionUsername()
 	if userId == "" {
 		c.ResponseError("Please sign in first")

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -17,7 +17,6 @@ package controllers
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/astaxie/beego"
 	"github.com/casbin/casdoor/object"
@@ -54,14 +53,6 @@ func (c *ApiController) ResponseError(error string, data ...interface{}) {
 
 // RequireSignedIn ...
 func (c *ApiController) RequireSignedIn() (string, bool) {
-	accessToken := strings.Split(c.Ctx.Request.Header.Get("Authorization"), " ")
-	if len(accessToken) > 1 {
-		claims, err := object.ParseJwtToken(accessToken[1])
-		if err == nil {
-			c.SetSessionUsername(fmt.Sprintf("%v/%v", claims.Owner, claims.Name))
-			c.SetSessionData(&SessionData{ExpireTime: claims.ExpiresAt.Unix()})
-		}
-	}
 	userId := c.GetSessionUsername()
 	if userId == "" {
 		c.ResponseError("Please sign in first")

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -16,6 +16,7 @@ package routers
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/astaxie/beego/context"
 	"github.com/casbin/casdoor/object"
@@ -61,5 +62,17 @@ func AutoSigninFilter(ctx *context.Context) {
 
 		setSessionUser(ctx, userId)
 		return
+	}
+
+	//Bearer token
+	//headers: {"Authorization":accessToken}
+	BearerToken := strings.Split(ctx.Request.Header.Get("Authorization"), " ")
+	if len(BearerToken) > 1 {
+		claims, err := object.ParseJwtToken(BearerToken[1])
+		if err == nil {
+			setSessionUser(ctx, fmt.Sprintf("%v/%v", claims.Owner, claims.Name))
+			setSeesionExpire(ctx, claims.ExpiresAt.Unix())
+			return
+		}
 	}
 }

--- a/routers/auto_signin_filter.go
+++ b/routers/auto_signin_filter.go
@@ -16,7 +16,6 @@ package routers
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/astaxie/beego/context"
 	"github.com/casbin/casdoor/object"
@@ -66,13 +65,9 @@ func AutoSigninFilter(ctx *context.Context) {
 
 	//Bearer token
 	//headers: {"Authorization":accessToken}
-	BearerToken := strings.Split(ctx.Request.Header.Get("Authorization"), " ")
-	if len(BearerToken) > 1 {
-		claims, err := object.ParseJwtToken(BearerToken[1])
-		if err == nil {
-			setSessionUser(ctx, fmt.Sprintf("%v/%v", claims.Owner, claims.Name))
-			setSeesionExpire(ctx, claims.ExpiresAt.Unix())
-			return
-		}
+	if claims, ok := parseBearer(ctx); ok {
+		setSessionUser(ctx, fmt.Sprintf("%s/%s", claims.Owner, claims.Name))
+		setSessionExpire(ctx, claims.ExpiresAt.Unix())
+		return
 	}
 }

--- a/routers/base.go
+++ b/routers/base.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/astaxie/beego/context"
 	"github.com/casbin/casdoor/object"
+	"github.com/casbin/casdoor/util"
 )
 
 type Response struct {
@@ -83,5 +84,14 @@ func setSessionUser(ctx *context.Context, user string) {
 	}
 
 	// https://github.com/beego/beego/issues/3445#issuecomment-455411915
+	ctx.Input.CruSession.SessionRelease(ctx.ResponseWriter)
+}
+
+func setSeesionExpire(ctx *context.Context, ExpireTime int64) {
+	SessionData := struct{ ExpireTime int64 }{ExpireTime: ExpireTime}
+	err := ctx.Input.CruSession.Set("SessionData", util.StructToJson(SessionData))
+	if err != nil {
+		panic(err)
+	}
 	ctx.Input.CruSession.SessionRelease(ctx.ResponseWriter)
 }


### PR DESCRIPTION
Fix: https://github.com/casbin/casdoor/issues/353

In the OIDC protocol, userinfo_endpoint often uses bearer token to access userinfo. In casdoor,  bearer token method is currently not supported, which makes it difficult to access some services, like Jenkins.