### PR TITLE
feat: support AuthnRequest in SAML

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -364,11 +364,12 @@ func (c *ApiController) Login() {
 
 func (c *ApiController) GetSamlLogin() {
 	providerId := c.Input().Get("id")
-	authURL, err := object.GenerateSamlLoginUrl(providerId)
+	relayState := c.Input().Get("relayState")
+	authURL, method, err := object.GenerateSamlLoginUrl(providerId, relayState)
 	if err != nil {
 		c.ResponseError(err.Error())
 	}
-	c.ResponseOk(authURL)
+	c.ResponseOk(authURL, method)
 }
 
 func (c *ApiController) HandleSamlLogin() {

--- a/object/provider.go
+++ b/object/provider.go
@@ -48,9 +48,10 @@ type Provider struct {
 	Domain           string `xorm:"varchar(100)" json:"domain"`
 	Bucket           string `xorm:"varchar(100)" json:"bucket"`
 
-	Metadata  string `xorm:"mediumtext" json:"metadata"`
-	IdP       string `xorm:"mediumtext" json:"idP"`
-	IssuerUrl string `xorm:"varchar(100)" json:"issuerUrl"`
+	Metadata               string `xorm:"mediumtext" json:"metadata"`
+	IdP                    string `xorm:"mediumtext" json:"idP"`
+	IssuerUrl              string `xorm:"varchar(100)" json:"issuerUrl"`
+	EnableSignAuthnRequest bool   `json:"enableSignAuthnRequest"`
 
 	ProviderUrl string `xorm:"varchar(200)" json:"providerUrl"`
 }

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from "react";
-import {Button, Card, Col, Input, InputNumber, Row, Select} from 'antd';
+import {Button, Card, Col, Input, InputNumber, Row, Select, Switch} from 'antd';
 import {LinkOutlined} from "@ant-design/icons";
 import * as ProviderBackend from "./backend/ProviderBackend";
 import * as Setting from "./Setting";
@@ -418,6 +418,16 @@ class ProviderEditPage extends React.Component {
             </React.Fragment>
           ) : this.state.provider.category === "SAML" ? (
             <React.Fragment>
+              <Row style={{marginTop: '20px'}} >
+                <Col style={{marginTop: '5px'}} span={(Setting.isMobile()) ? 22 : 2}>
+                  {Setting.getLabel(i18next.t("provider:Sign request"), i18next.t("provider:Sign request - Tooltip"))} :
+                </Col>
+                <Col span={22} >
+                  <Switch checked={this.state.provider.enableSignAuthnRequest} onChange={checked => {
+                    this.updateProviderField('enableSignAuthnRequest', checked);
+                  }} />
+                </Col>
+              </Row>
               <Row style={{marginTop: '20px'}} >
                 <Col style={{marginTop: '5px'}} span={(Setting.isMobile()) ? 22 : 2}>
                   {Setting.getLabel(i18next.t("provider:Metadata"), i18next.t("provider:Metadata - Tooltip"))} :

--- a/web/src/auth/AuthBackend.js
+++ b/web/src/auth/AuthBackend.js
@@ -77,8 +77,8 @@ export function unlink(values) {
   }).then(res => res.json());
 }
 
-export function getSamlLogin(providerId) {
-  return fetch(`${authConfig.serverUrl}/api/get-saml-login?id=${providerId}`, {
+export function getSamlLogin(providerId, relayState) {
+  return fetch(`${authConfig.serverUrl}/api/get-saml-login?id=${providerId}&relayState=${relayState}`, {
     method: 'GET',
     credentials: 'include',
   }).then(res => res.json());

--- a/web/src/auth/LoginPage.js
+++ b/web/src/auth/LoginPage.js
@@ -201,9 +201,13 @@ class LoginPage extends React.Component {
     let realRedirectUri = params.get("redirect_uri");
     let redirectUri = `${window.location.origin}/callback/saml`;
     let providerName = provider.name;
-    AuthBackend.getSamlLogin(`${provider.owner}/${providerName}`).then((res) => {
-      const replyState = `${clientId}&${application}&${providerName}&${realRedirectUri}&${redirectUri}`;
-      window.location.href = `${res.data}&RelayState=${btoa(replyState)}`;
+    let relayState = `${clientId}&${application}&${providerName}&${realRedirectUri}&${redirectUri}`;
+    AuthBackend.getSamlLogin(`${provider.owner}/${providerName}`, btoa(relayState)).then((res) => {
+      if (res.data2 === "POST") {
+        document.write(res.data)
+      } else {
+        window.location.href = res.data
+      }
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com>

Fix: https://github.com/casbin/casdoor/issues/368

I added an option as below to determine whether to sign the request. If enabled, the certification should be uploaded to Keycloak Clients. I will update the documentation later.

![image](https://user-images.githubusercontent.com/33992371/146147076-b2e9ff12-67e2-4a0c-b854-d2f3c17aed51.png)

However, there were some troubles during the development process. The gosaml2 lib seems to have some bugs about this point, and I have opened an [issue](https://github.com/russellhaering/gosaml2/issues/89). 

So if enable the option, we will use POST binding instead of Redirect binding. 

When tested with Aliyun IDaaS, the certification management function is VIP. And I can't find an option like `Client Signature Required` in Keycloak. So I suggest disable the option while using Aliyun IDaaS.
