### PR TITLE
feat: add OIDC nonce and sub support.

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -61,6 +61,7 @@ type RequestForm struct {
 type Response struct {
 	Status string      `json:"status"`
 	Msg    string      `json:"msg"`
+	Sub    string      `json:"sub"`
 	Data   interface{} `json:"data"`
 	Data2  interface{} `json:"data2"`
 }
@@ -217,8 +218,14 @@ func (c *ApiController) GetAccount() {
 	}
 
 	organization := object.GetMaskedOrganization(object.GetOrganizationByUser(user))
-
-	c.ResponseOk(user, organization)
+	resp := Response{
+		Status: "ok",
+		Sub:    userId,
+		Data:   user,
+		Data2:  organization,
+	}
+	c.Data["json"] = resp
+	c.ServeJSON()
 }
 
 // GetHumanCheck ...

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -51,8 +51,8 @@ func (c *ApiController) HandleLoggedIn(application *object.Application, user *ob
 		redirectUri := c.Input().Get("redirectUri")
 		scope := c.Input().Get("scope")
 		state := c.Input().Get("state")
-
-		code := object.GetOAuthCode(userId, clientId, responseType, redirectUri, scope, state)
+		nonce := c.Input().Get("nonce")
+		code := object.GetOAuthCode(userId, clientId, responseType, redirectUri, scope, state, nonce)
 		resp = codeToResponse(code)
 
 		if application.HasPromptPage() {

--- a/controllers/token.go
+++ b/controllers/token.go
@@ -136,8 +136,9 @@ func (c *ApiController) GetOAuthCode() {
 	redirectUri := c.Input().Get("redirect_uri")
 	scope := c.Input().Get("scope")
 	state := c.Input().Get("state")
+	nonce := c.Input().Get("nonce")
 
-	c.Data["json"] = object.GetOAuthCode(userId, clientId, responseType, redirectUri, scope, state)
+	c.Data["json"] = object.GetOAuthCode(userId, clientId, responseType, redirectUri, scope, state, nonce)
 	c.ServeJSON()
 }
 

--- a/object/token.go
+++ b/object/token.go
@@ -175,7 +175,7 @@ func CheckOAuthLogin(clientId string, responseType string, redirectUri string, s
 	return "", application
 }
 
-func GetOAuthCode(userId string, clientId string, responseType string, redirectUri string, scope string, state string) *Code {
+func GetOAuthCode(userId string, clientId string, responseType string, redirectUri string, scope string, state string, nonce string) *Code {
 	user := GetUser(userId)
 	if user == nil {
 		return &Code{
@@ -192,7 +192,7 @@ func GetOAuthCode(userId string, clientId string, responseType string, redirectU
 		}
 	}
 
-	accessToken, err := generateJwtToken(application, user)
+	accessToken, err := generateJwtToken(application, user, nonce)
 	if err != nil {
 		panic(err)
 	}

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -31,17 +31,19 @@ var tokenJwtPrivateKey string
 
 type Claims struct {
 	User
+	Nonce string `json:"nonce,omitempty"`
 	jwt.RegisteredClaims
 }
 
-func generateJwtToken(application *Application, user *User) (string, error) {
+func generateJwtToken(application *Application, user *User, nonce string) (string, error) {
 	nowTime := time.Now()
 	expireTime := nowTime.Add(time.Duration(application.ExpireInHours) * time.Hour)
 
 	user.Password = ""
 
 	claims := Claims{
-		User: *user,
+		User:  *user,
+		Nonce: nonce,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    beego.AppConfig.String("origin"),
 			Subject:   user.Id,

--- a/web/src/auth/AuthBackend.js
+++ b/web/src/auth/AuthBackend.js
@@ -44,7 +44,7 @@ function oAuthParamsToQuery(oAuthParams) {
   }
 
   // code
-  return `?clientId=${oAuthParams.clientId}&responseType=${oAuthParams.responseType}&redirectUri=${oAuthParams.redirectUri}&scope=${oAuthParams.scope}&state=${oAuthParams.state}`;
+  return `?clientId=${oAuthParams.clientId}&responseType=${oAuthParams.responseType}&redirectUri=${oAuthParams.redirectUri}&scope=${oAuthParams.scope}&state=${oAuthParams.state}&nonce=${oAuthParams.nonce}`;
 }
 
 export function getApplicationLogin(oAuthParams) {

--- a/web/src/auth/Util.js
+++ b/web/src/auth/Util.js
@@ -82,6 +82,7 @@ export function getOAuthGetParameters(params) {
   const redirectUri = queries.get("redirect_uri");
   const scope = queries.get("scope");
   const state = queries.get("state");
+  const nonce = queries.get("nonce")
 
   if (clientId === undefined || clientId === null) {
     // login
@@ -94,6 +95,7 @@ export function getOAuthGetParameters(params) {
       redirectUri: redirectUri,
       scope: scope,
       state: state,
+      nonce: nonce,
     };
   }
 }


### PR DESCRIPTION
Fix: https://github.com/casbin/casdoor/issues/358

1. add nonce parameter.
    Some packages  like [lua-resty-openidc](https://github.com/zmartzone/lua-resty-openidc) verify that the nonce is the same in request and  response, so nonce support needs to be added.
2. add sub in userinfo endpoint.
    Some applications need to verify the sub in the userinfo endpoint, so add it. There may be a better implementation later.

Signed-off-by: 0x2a <stevesough@gmail.com>