### PR TITLE
fix: wrong sub return and docker-compose boolean value error.

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -25,7 +25,7 @@ func GetBeegoConfDataSourceName() string {
 	dataSourceName := beego.AppConfig.String("dataSourceName")
 
 	runningInDocker := os.Getenv("RUNNING_IN_DOCKER")
-	if runningInDocker != "" {
+	if runningInDocker == "true" {
 		dataSourceName = strings.ReplaceAll(dataSourceName, "localhost", "host.docker.internal")
 	}
 

--- a/controllers/account.go
+++ b/controllers/account.go
@@ -220,7 +220,7 @@ func (c *ApiController) GetAccount() {
 	organization := object.GetMaskedOrganization(object.GetOrganizationByUser(user))
 	resp := Response{
 		Status: "ok",
-		Sub:    userId,
+		Sub:    user.Id,
 		Data:   user,
 		Data2:  organization,
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - db
     environment:
-      RUNNING_IN_DOCKER: true
+      RUNNING_IN_DOCKER: "true"
     volumes:
       - ./conf:/conf/
   db:


### PR DESCRIPTION
1. in get-account api, sub should reruen user's id instead of user's name.
2. according to [this document](https://docs.docker.com/compose/compose-file/compose-file-v3/#environment), any boolean values (true, false, yes, no) need to be enclosed in quotes to ensure they are not converted to True or False by the YML parser.