### PR TITLE
fix: adjust the accessToken field

### DIFF
--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -30,7 +30,9 @@ var tokenJwtPublicKey string
 var tokenJwtPrivateKey string
 
 type Claims struct {
-	User
+	*User
+	Name  string `json:"name,omitempty"`
+	Owner string `json:"owner,omitempty"`
 	Nonce string `json:"nonce,omitempty"`
 	jwt.RegisteredClaims
 }
@@ -43,7 +45,7 @@ func generateJwtToken(application *Application, user *User, nonce string) (strin
 	user.Password = ""
 
 	claims := Claims{
-		User:  *user,
+		User:  user,
 		Nonce: nonce,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    beego.AppConfig.String("origin"),
@@ -55,9 +57,11 @@ func generateJwtToken(application *Application, user *User, nonce string) (strin
 			ID:        "",
 		},
 	}
-
+	//all fields of the User struct are not added in "JWT-Empty" format
 	if application.TokenFormat == "JWT-Empty" {
-		claims.User = User{}
+		claims.User = nil
+		claims.Name = user.Name
+		claims.Owner = user.Owner
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -60,9 +60,9 @@ func generateJwtToken(application *Application, user *User, nonce string) (strin
 	//all fields of the User struct are not added in "JWT-Empty" format
 	if application.TokenFormat == "JWT-Empty" {
 		claims.User = nil
-		claims.Name = user.Name
-		claims.Owner = user.Owner
 	}
+	claims.Name = user.Name
+	claims.Owner = user.Owner
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	claims.ExpiresAt = jwt.NewNumericDate(refreshExpireTime)


### PR DESCRIPTION
When the user uses "JWT-Empty", userinfo will not be returned, but since casdoor currently requires name and owner for accessToken authentication, two additional fields are added.
Signed-off-by: 0x2a <stevesough@gmail.com>