### PR TITLE
[fix] Add "nonce" into the OAuth and OIDC tokens, for some apps require "nonce" to integrate

### DIFF
--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -155,7 +155,8 @@ func (c *ApiController) HandleLoggedIn(application *object.Application, user *ob
 			resp = &Response{Status: "error", Msg: fmt.Sprintf("error: grant_type: %s is not supported in this application", form.Type), Data: ""}
 		} else {
 			scope := c.Input().Get("scope")
-			token, _ := object.GetTokenByUser(application, user, scope, c.Ctx.Request.Host)
+			nonce := c.Input().Get("nonce")
+			token, _ := object.GetTokenByUser(application, user, scope, nonce, c.Ctx.Request.Host)
 			resp = tokenToResponse(token)
 		}
 	} else if form.Type == ResponseTypeSaml { // saml flow

--- a/object/token.go
+++ b/object/token.go
@@ -754,13 +754,13 @@ func GetClientCredentialsToken(application *Application, clientSecret string, sc
 
 // GetTokenByUser
 // Implicit flow
-func GetTokenByUser(application *Application, user *User, scope string, host string) (*Token, error) {
+func GetTokenByUser(application *Application, user *User, scope string, nonce string, host string) (*Token, error) {
 	err := ExtendUserWithRolesAndPermissions(user)
 	if err != nil {
 		return nil, err
 	}
 
-	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, "", scope, host)
+	accessToken, refreshToken, tokenName, err := generateJwtToken(application, user, nonce, scope, host)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
See for example:
https://github.com/casbin/casdoor/issues/1469

Also any apps using django-rest-social-auth (such as Apache Superset) will have problems logging in with Casdoor as OIDC provider without the nonce in the token:
https://github.com/st4lk/django-rest-social-auth/issues/41

Full credit to @rwayan
I need the fix so I opend the PR:
https://github.com/casbin/casdoor/issues/1469#issuecomment-1408848287