### PR TITLE
feat: helm support extra containers

### DIFF
--- a/manifests/casdoor/Chart.yaml
+++ b/manifests/casdoor/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.17.0"

--- a/manifests/casdoor/templates/deployment.yaml
+++ b/manifests/casdoor/templates/deployment.yaml
@@ -59,6 +59,9 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /conf
+        {{ if .Values.extraContainersEnabled }}
+          {{- .Values.extraContainers | nindent 8 }}
+        {{- end }}
       volumes:
        - name: config-volume
          projected:

--- a/manifests/casdoor/values.yaml
+++ b/manifests/casdoor/values.yaml
@@ -108,3 +108,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# -- Optionally add extra sidecar containers.
+extraContainersEnabled: false
+extraContainers: ""
+# extraContainers: |
+#  - name: ...
+#    image: ...


### PR DESCRIPTION
**What**
- Update Helm Chart to support extra containers

**Why**
- Allows multiple containers to run within the pod

**Use Case**
- Needed to add a cloud SQL proxy side car container for GCP (recommended Pattern)

> Note: For connecting from Google Kubernetes Engine, we recommend running the Cloud SQL Auth Proxy in a sidecar pattern, as an [additional container](https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#run_the_as_a_sidecar) that shares a pod with your application. Also see the related [quickstart](https://cloud.google.com/sql/docs/mysql/connect-instance-kubernetes).  ([GCP Docs](https://cloud.google.com/sql/docs/mysql/connect-auth-proxy))

**How was it Tested**
-  Successfully added side car container without issues