### PR TITLE
fix: Fix secret information leakage in the CAPTCHA and bypass verification by setting "none"

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -479,7 +479,7 @@ func (c *ApiController) GetCaptcha() {
 				Type:          captchaProvider.Type,
 				SubType:       captchaProvider.SubType,
 				ClientId:      captchaProvider.ClientId,
-				ClientSecret:  captchaProvider.ClientSecret,
+				ClientSecret:  "***",
 				ClientId2:     captchaProvider.ClientId2,
 				ClientSecret2: captchaProvider.ClientSecret2,
 			})

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -387,6 +387,16 @@ func (c *ApiController) Login() {
 				c.ResponseError(err.Error())
 				return
 			} else if enableCaptcha {
+				captchaProvider, err := object.GetCaptchaProviderByApplication(util.GetId(application.Owner, application.Name), "false", c.GetAcceptLanguage())
+				if err != nil {
+					c.ResponseError(err.Error())
+					return
+				}
+
+				if captchaProvider.Type != "Default" {
+					authForm.ClientSecret = captchaProvider.ClientSecret
+				}
+
 				var isHuman bool
 				isHuman, err = captcha.VerifyCaptchaByCaptchaType(authForm.CaptchaType, authForm.CaptchaToken, authForm.ClientSecret)
 				if err != nil {

--- a/web/src/backend/UserBackend.js
+++ b/web/src/backend/UserBackend.js
@@ -153,11 +153,12 @@ export function sendCode(captchaType, captchaToken, clientSecret, method, countr
   });
 }
 
-export function verifyCaptcha(captchaType, captchaToken, clientSecret) {
+export function verifyCaptcha(owner, name, captchaType, captchaToken, clientSecret) {
   const formData = new FormData();
   formData.append("captchaType", captchaType);
   formData.append("captchaToken", captchaToken);
   formData.append("clientSecret", clientSecret);
+  formData.append("applicationId", `${owner}/${name}`);
   return fetch(`${Setting.ServerUrl}/api/verify-captcha`, {
     method: "POST",
     credentials: "include",

--- a/web/src/common/CaptchaPreview.js
+++ b/web/src/common/CaptchaPreview.js
@@ -50,7 +50,7 @@ export const CaptchaPreview = (props) => {
   };
 
   const onOk = (captchaType, captchaToken, clientSecret) => {
-    UserBackend.verifyCaptcha(captchaType, captchaToken, clientSecret).then(() => {
+    UserBackend.verifyCaptcha(owner, name, captchaType, captchaToken, clientSecret).then(() => {
       setVisible(false);
     });
   };


### PR DESCRIPTION
fix #2471
For details about the security issues associated with this pull request, please refer to #2471.

## Changes
To prevent the leakage of the `ClientSecret` information from the CAPTCHA provider, the `/api/get-captcha` endpoint will no longer return the actual `ClientSecret` and will be replaced with `***`. When validating the CAPTCHA, the required `ClientSecret` will be obtained from the CAPTCHA provider associated with the application on the server-side. 

To prevent malicious attackers from bypassing the CAPTCHA by setting the `CaptchaType` to `"none"` in the `api/send-verification-code` request, a comparison will be made between the `CaptchaType` field in the request and the `Type` field obtained from the CAPTCHA provider in the application. This is done to prevent attackers from maliciously bypassing the verification process.