### PR TITLE
feat: add helm release github action

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,40 @@
+name: Helm Release
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'manifests/casdoor/Chart.yaml'
+
+jobs:
+  release-helm-chart:
+    name: Release Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Release Helm Chart
+        run: |
+          cd manifests/casdoor
+          REGISTRY=oci://registry-1.docker.io/casbin
+          helm package .
+          PKG_NAME=$(ls *.tgz)
+          helm repo index . --url $REGISTRY --merge index.yaml
+          helm push $PKG_NAME $REGISTRY
+          rm $PKG_NAME
+
+      - name: Commit updated helm index.yaml
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'ci: update helm index.yaml'

--- a/manifests/casdoor/Chart.yaml
+++ b/manifests/casdoor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: casdoor
+name: casdoor-helm-charts
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.17.0"
+appVersion: "1.18.0"


### PR DESCRIPTION
Fix: https://github.com/casbin/casdoor/issues/2532

**Description**
- Update CI to publish Helm Chart to Docker Hub

**Why**
- Easier onboarding for developers to use casdoor helm chart
- https://github.com/casbin/casdoor/issues/2532

**How**
- CI will package the binary for helm chart before pushing to docker hub
- CI will update the index.yaml that references the binary in docker hub

**How was it Tested?**
- Tested in Forked [Repo](https://github.com/sp71/casdoor/pull/3) and was able to publish to personal [dockerhub](https://hub.docker.com/repository/docker/satindersingh71/casdoor-helm-charts/general)