### PR TITLE
fix: helm add index.yaml

### DIFF
--- a/manifests/casdoor/Chart.yaml
+++ b/manifests/casdoor/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.477.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.18.0"
+appVersion: "1.477.0"

--- a/manifests/casdoor/index.yaml
+++ b/manifests/casdoor/index.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+entries:
+  casdoor-helm-charts:
+  - apiVersion: v2
+    appVersion: 1.477.0
+    created: "2023-12-17T21:46:07.221564-08:00"
+    description: A Helm chart for Kubernetes
+    digest: 14da89d0c62697e9e4ff878de56382b0ac0e79f8a6471791d0ec446a89bc0848
+    name: casdoor-helm-charts
+    type: application
+    urls:
+    - oci://registry-1.docker.io/casbin/casdoor-helm-charts-1.477.0.tgz
+    version: 1.477.0
+generated: "2023-12-17T21:46:07.221115-08:00"


### PR DESCRIPTION
**Description**
- Index.yaml was not being generated by Github Action because it was being ignored
- Adding file into git so it will be tracked
- File necessary as it informs clients where to download helm chart from
- Updated app version to match latest