### PR TITLE
feat: add users with correct application

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -392,7 +392,7 @@ class App extends Component {
             </div>
           </Tooltip>
           <OpenTour />
-          {Setting.isAdminUser(this.state.account) && !Setting.isMobile() &&
+          {Setting.isAdminUser(this.state.account) && !Setting.isMobile() && (this.state.uri.indexOf("/trees") === -1) &&
             <OrganizationSelect
               initValue={Setting.getOrganization()}
               withAll={true}

--- a/web/src/BaseListPage.js
+++ b/web/src/BaseListPage.js
@@ -25,6 +25,7 @@ class BaseListPage extends React.Component {
     super(props);
     this.state = {
       classes: props,
+      organizationName: this.props.match?.params.organizationName || Setting.getRequestOrganization(this.props.account),
       data: [],
       pagination: {
         current: 1,
@@ -39,6 +40,10 @@ class BaseListPage extends React.Component {
   }
 
   handleOrganizationChange = () => {
+    this.setState({
+      organizationName: this.props.match?.params.organizationName || Setting.getRequestOrganization(this.props.account),
+    });
+
     const {pagination} = this.state;
     this.fetch({pagination});
   };

--- a/web/src/UserListPage.js
+++ b/web/src/UserListPage.js
@@ -30,7 +30,6 @@ class UserListPage extends BaseListPage {
     super(props);
     this.state = {
       ...this.state,
-      organizationName: this.props.organizationName ?? this.props.match?.params.organizationName ?? this.props.account.owner,
       organization: null,
     };
   }
@@ -62,7 +61,7 @@ class UserListPage extends BaseListPage {
 
   newUser() {
     const randomName = Setting.getRandomName();
-    const owner = Setting.isDefaultOrganizationSelected(this.props.account) ? this.state.organizationName : Setting.getRequestOrganization(this.props.account);
+    const owner = (Setting.isDefaultOrganizationSelected(this.props.account) || this.props.groupName) ? this.state.organizationName : Setting.getRequestOrganization(this.props.account);
     return {
       owner: owner,
       name: `user_${randomName}`,
@@ -85,7 +84,7 @@ class UserListPage extends BaseListPage {
       score: this.state.organization.initScore,
       isDeleted: false,
       properties: {},
-      signupApplication: "app-built-in",
+      signupApplication: this.state.organization.defaultApplication,
     };
   }
 


### PR DESCRIPTION
 `signup application` is set `app-built-in` for all default users added in web UI. It cause some unmatches in some scenario when getting organization properties by use the signup application of user.

The pr make sure set the `signup application` of added users to fit the current context organization and hidden the organziaton select componet in orgnization tree page because of the duplication and misleadingness.

https://github.com/casbin/casdoor/assets/71440988/b608765c-87ee-4cf5-8083-77a16f7a4796

![image](https://github.com/casbin/casdoor/assets/71440988/4ccf3a89-1f92-4d20-8494-41fdaa4bef0b)

