### PR TITLE
feat: fix dropped getAffiliationMap error in object

### DIFF
--- a/object/syncer_sync.go
+++ b/object/syncer_sync.go
@@ -54,6 +54,15 @@ func (syncer *Syncer) syncUsers() error {
 	var affiliationMap map[int]string
 	if syncer.AffiliationTable != "" {
 		_, affiliationMap, err = syncer.getAffiliationMap()
+		if err != nil {
+			line := fmt.Sprintf("[%s] %s\n", util.GetCurrentTime(), err.Error())
+			_, err2 := updateSyncerErrorText(syncer, line)
+			if err2 != nil {
+				panic(err2)
+			}
+
+			return err
+		}
 	}
 
 	key := syncer.getKey()


### PR DESCRIPTION
This fixes a dropped `err` variable in the `object` package.