### PR TITLE
feat: helm hpa yaml must reference correct apiVersion

### DIFF
--- a/manifests/casdoor/templates/hpa.yaml
+++ b/manifests/casdoor/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "casdoor.fullname" . }}
@@ -17,12 +17,15 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
**DESCRIPTION**
- Helm HPA YAML references incorrect apiVersion
- Fix is to apply correct version
- `autoscaling/v2`  uses a different schema for target setting

**HOW WAS IT TESTED?**
- Increased pod count on GCP using this helm chart from 1 to 3 successfully
- Before this change, it would error out

**WHY**
- The beta version was [deprecated](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126) for kubernetes and modern kubernetes engines will error out