### PR TITLE
chore: update helm version to v1.492.0

### DIFF
--- a/manifests/casdoor/Chart.yaml
+++ b/manifests/casdoor/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.3.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.18.0"
+appVersion: "v1.492.0"


### PR DESCRIPTION
According to https://hub.docker.com/r/casbin/casdoor/tags and https://github.com/casbin/casdoor/releases latest version is `v1.492.0`

The process can be automated. See https://github.com/casbin/casdoor/pull/2583