### PR TITLE
fix: add vscode local debugging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ bin/
 
 .idea/
 *.iml
-.vscode/
+.vscode/settings.json
 
 tmp/
 tmpFiles/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}",
+            "cwd": "${workspaceFolder}",
+            "debugAdapter": "dlv-dap",
+            "args": ["--createDatabase=true"]
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ docker-build: ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	docker push ${REGISTRY}/${IMG}:${IMG_TAG}
 
+deps: ## Run dependencies for local development
+	docker compose up -d db
+
 lint-install: ## Install golangci-lint
 	@# The following installs a specific version of golangci-lint, which is appropriate for a CI server to avoid different results from build to build
 	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.40.1


### PR DESCRIPTION
**Description**
- Add Support to run casdoor in VsCode with debugger

**Why**
- Easier to debug issues and understand codebase with modern debuggers

**How**
- Added makefile command to spin up dependencies via docker

**Testing Changes**
- Ran `make deps` -> Successfully brought up dependencies for casdoor
- VsCode Run and Debug Menu -> Select Start Debugging
- Sent request locally and debugger triggered on breakpoint

**Curl Request**

```
curl localhost:8000/api/health  
{
  "status": "ok",
  "msg": "",
  "sub": "",
  "name": "",
  "data": null,
  "data2": null
}
```

VSCode Debugger

<img width="863" alt="294722388-2c1a59b2-2414-4829-8b50-aaf0f41141ba" src="https://github.com/casbin/casdoor/assets/6192130/305e6c21-4b33-406b-8e55-eb45a775f891">

