### PR TITLE
feat: ci should commit index.yaml and push to docker hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,9 +225,17 @@ jobs:
           newChartVersion=$(echo $currentChartVersion | awk -F. -v OFS=. '{$NF++;print}')
           sed -i "s/version: .*/version: $newChartVersion/g" ./charts/casdoor/Chart.yaml
 
+          REGISTRY=oci://registry-1.docker.io/casbin
+          cd charts/casdoor
+          helm package .
+          PKG_NAME=$(ls *.tgz)
+          helm repo index . --url $REGISTRY --merge index.yaml
+          helm push $PKG_NAME $REGISTRY
+          rm $PKG_NAME
+
           # Commit and push the changes back to the repository
           git config --global user.name "casbin-bot"
           git config --global user.email "casbin-bot@github.com"
-          git add ./charts/casdoor/Chart.yaml
+          git add Chart.yaml index.yaml
           git commit -m "chore(helm): bump helm charts appVersion to ${{steps.get-current-tag.outputs.tag }}"
           git push origin HEAD:master


### PR DESCRIPTION
Fix https://github.com/casdoor/casdoor-helm/issues/5
Related https://github.com/casdoor/casdoor-helm/pull/6

Casdoor should commit generated index.yaml to separate helm repo and publish helm package to docker hub. This centralizes the helm publishing workflow logic and ensure the generated index yaml is always committed and in sync with the published docker hub package