### PR TITLE
fix: fix bug in LDAP user login error count

### DIFF
--- a/object/check.go
+++ b/object/check.go
@@ -314,7 +314,7 @@ func checkLdapUserPassword(user *User, password string, lang string) error {
 		}
 		return fmt.Errorf(i18n.Translate(lang, "check:LDAP user name or password incorrect"))
 	}
-	return nil
+	return resetUserSigninErrorTimes(user)
 }
 
 func CheckUserPassword(organization string, username string, password string, lang string, options ...bool) (*User, error) {


### PR DESCRIPTION
Fix the issue where the login error count is not reset to 0 after a successful LDAP user login.