### PR TITLE
feat: Support sha512 password encryption algorithm

### DIFF
--- a/controllers/application.go
+++ b/controllers/application.go
@@ -139,6 +139,10 @@ func (c *ApiController) GetUserApplication() {
 		c.ResponseError(err.Error())
 		return
 	}
+	if application == nil {
+		c.ResponseError(fmt.Sprintf(c.T("general:The organization: %s should have one application at least"), user.Owner))
+		return
+	}
 
 	c.ResponseOk(object.GetMaskedApplication(application, userId))
 }

--- a/cred/manager.go
+++ b/cred/manager.go
@@ -24,6 +24,8 @@ func GetCredManager(passwordType string) CredManager {
 		return NewPlainCredManager()
 	} else if passwordType == "salt" {
 		return NewSha256SaltCredManager()
+	} else if passwordType == "sha512-salt" {
+		return NewSha512SaltCredManager()
 	} else if passwordType == "md5-salt" {
 		return NewMd5UserSaltCredManager()
 	} else if passwordType == "bcrypt" {

--- a/cred/sha512-salt.go
+++ b/cred/sha512-salt.go
@@ -1,0 +1,50 @@
+// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cred
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+)
+
+type Sha512SaltCredManager struct{}
+
+func getSha512(data []byte) []byte {
+	hash := sha512.Sum512(data)
+	return hash[:]
+}
+
+func getSha512HexDigest(s string) string {
+	b := getSha512([]byte(s))
+	res := hex.EncodeToString(b)
+	return res
+}
+
+func NewSha512SaltCredManager() *Sha512SaltCredManager {
+	cm := &Sha512SaltCredManager{}
+	return cm
+}
+
+func (cm *Sha512SaltCredManager) GetHashedPassword(password string, userSalt string, organizationSalt string) string {
+	res := getSha512HexDigest(password)
+	if organizationSalt != "" {
+		res = getSha512HexDigest(res + organizationSalt)
+	}
+	return res
+}
+
+func (cm *Sha512SaltCredManager) IsPasswordCorrect(plainPwd string, hashedPwd string, userSalt string, organizationSalt string) bool {
+	return hashedPwd == cm.GetHashedPassword(plainPwd, userSalt, organizationSalt)
+}

--- a/object/adapter.go
+++ b/object/adapter.go
@@ -37,7 +37,7 @@ type Adapter struct {
 	Host         string `xorm:"varchar(100)" json:"host"`
 	Port         int    `json:"port"`
 	User         string `xorm:"varchar(100)" json:"user"`
-	Password     string `xorm:"varchar(100)" json:"password"`
+	Password     string `xorm:"varchar(150)" json:"password"`
 	Database     string `xorm:"varchar(100)" json:"database"`
 
 	*xormadapter.Adapter `xorm:"-" json:"-"`

--- a/object/syncer.go
+++ b/object/syncer.go
@@ -43,7 +43,7 @@ type Syncer struct {
 	Host             string         `xorm:"varchar(100)" json:"host"`
 	Port             int            `json:"port"`
 	User             string         `xorm:"varchar(100)" json:"user"`
-	Password         string         `xorm:"varchar(100)" json:"password"`
+	Password         string         `xorm:"varchar(150)" json:"password"`
 	Database         string         `xorm:"varchar(100)" json:"database"`
 	Table            string         `xorm:"varchar(100)" json:"table"`
 	TableColumns     []*TableColumn `xorm:"mediumtext" json:"tableColumns"`

--- a/object/token_jwt.go
+++ b/object/token_jwt.go
@@ -51,7 +51,7 @@ type UserWithoutThirdIdp struct {
 
 	Id                string   `xorm:"varchar(100) index" json:"id"`
 	Type              string   `xorm:"varchar(100)" json:"type"`
-	Password          string   `xorm:"varchar(100)" json:"password"`
+	Password          string   `xorm:"varchar(150)" json:"password"`
 	PasswordSalt      string   `xorm:"varchar(100)" json:"passwordSalt"`
 	PasswordType      string   `xorm:"varchar(100)" json:"passwordType"`
 	DisplayName       string   `xorm:"varchar(100)" json:"displayName"`

--- a/object/user.go
+++ b/object/user.go
@@ -53,7 +53,7 @@ type User struct {
 	Id                string   `xorm:"varchar(100) index" json:"id"`
 	ExternalId        string   `xorm:"varchar(100) index" json:"externalId"`
 	Type              string   `xorm:"varchar(100)" json:"type"`
-	Password          string   `xorm:"varchar(100)" json:"password"`
+	Password          string   `xorm:"varchar(150)" json:"password"`
 	PasswordSalt      string   `xorm:"varchar(100)" json:"passwordSalt"`
 	PasswordType      string   `xorm:"varchar(100)" json:"passwordType"`
 	DisplayName       string   `xorm:"varchar(100)" json:"displayName"`

--- a/web/src/OrganizationEditPage.js
+++ b/web/src/OrganizationEditPage.js
@@ -184,7 +184,7 @@ class OrganizationEditPage extends React.Component {
           </Col>
           <Col span={22} >
             <Select virtual={false} style={{width: "100%"}} value={this.state.organization.passwordType} onChange={(value => {this.updateOrganizationField("passwordType", value);})}
-              options={["plain", "salt", "md5-salt", "bcrypt", "pbkdf2-salt", "argon2id"].map(item => Setting.getOption(item, item))}
+              options={["plain", "salt", "sha512-salt", "md5-salt", "bcrypt", "pbkdf2-salt", "argon2id"].map(item => Setting.getOption(item, item))}
             />
           </Col>
         </Row>


### PR DESCRIPTION
Fix #2641 

1. add sha512 encryption support for password
2. extend the length of password to 150
3. add sha512-salt option in the frontend

ScreenShots:

![image](https://github.com/casbin/casdoor/assets/47297289/7a755d33-0b1d-49b7-a00c-9925952e8e99)
