### PR TITLE
feat: Support WeChat Official Accounts login on PC

### DIFF
--- a/authz/authz.go
+++ b/authz/authz.go
@@ -53,6 +53,7 @@ p, *, *, GET, /api/user, *, *
 p, *, *, GET, /api/health, *, *
 p, *, *, POST, /api/webhook, *, *
 p, *, *, GET, /api/get-webhook-event, *, *
+p, *, *, GET, /api/webhook, *, *
 p, *, *, GET, /api/get-captcha-status, *, *
 p, *, *, *, /api/login/oauth, *, *
 p, *, *, GET, /api/get-application, *, *

--- a/controllers/auth.go
+++ b/controllers/auth.go
@@ -39,6 +39,7 @@ import (
 
 var (
 	wechatScanType string
+	openId         string
 	lock           sync.RWMutex
 )
 
@@ -928,9 +929,10 @@ func (c *ApiController) HandleOfficialAccountEvent() {
 	}
 
 	var data struct {
-		MsgType  string `xml:"MsgType"`
-		Event    string `xml:"Event"`
-		EventKey string `xml:"EventKey"`
+		MsgType      string `xml:"MsgType"`
+		Event        string `xml:"Event"`
+		EventKey     string `xml:"EventKey"`
+		FromUserName string `xml:"FromUserName"`
 	}
 	err = xml.Unmarshal(respBytes, &data)
 	if err != nil {
@@ -942,6 +944,7 @@ func (c *ApiController) HandleOfficialAccountEvent() {
 	defer lock.Unlock()
 	if data.EventKey != "" {
 		wechatScanType = data.Event
+		openId = data.FromUserName
 		c.Ctx.WriteString("")
 	}
 }
@@ -958,9 +961,24 @@ func (c *ApiController) GetWebhookEventType() {
 		Status: "ok",
 		Msg:    "",
 		Data:   wechatScanType,
+		Data2:  openId,
 	}
 	c.Data["json"] = resp
 	wechatScanType = ""
+	openId = ""
+	c.ServeJSON()
+}
+
+// WXOfficialAccountToken ...
+// @Title WXOfficialAccountToken
+// @Tag System API
+// @Description Return echostr,prove identity
+// @router /api/webhook [GET]
+// @Success 200 {object} object.Userinfo The Response object
+func (c *ApiController) WXOfficialAccountToken() {
+	s := c.Ctx.Request.FormValue("echostr")
+	echostr, _ := strconv.Atoi(s)
+	c.SetData(echostr)
 	c.ServeJSON()
 }
 

--- a/idp/provider.go
+++ b/idp/provider.go
@@ -66,7 +66,10 @@ func GetIdProvider(idpInfo *ProviderInfo, redirectUrl string) (IdProvider, error
 	case "QQ":
 		return NewQqIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
 	case "WeChat":
-		return NewWeChatIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
+		if idpInfo.ClientId != "" {
+			return NewWeChatIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
+		}
+		return NewWeChatOAIdProvider(idpInfo.ClientId2, idpInfo.ClientSecret2, redirectUrl), nil
 	case "Facebook":
 		return NewFacebookIdProvider(idpInfo.ClientId, idpInfo.ClientSecret, redirectUrl), nil
 	case "DingTalk":

--- a/idp/wechat_oa.go
+++ b/idp/wechat_oa.go
@@ -1,0 +1,96 @@
+// Copyright 2021 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idp
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// Wechat Official Accounts
+type WeChatOAIdProvider struct {
+	Client *http.Client
+	Config *oauth2.Config
+}
+
+func NewWeChatOAIdProvider(clientId string, clientSecret string, redirectUrl string) *WeChatOAIdProvider {
+	idp := &WeChatOAIdProvider{}
+
+	config := idp.getConfig(clientId, clientSecret, redirectUrl)
+	idp.Config = config
+
+	return idp
+}
+
+func (idp *WeChatOAIdProvider) SetHttpClient(client *http.Client) {
+	idp.Client = client
+}
+
+// getConfig return a point of Config, which describes a typical 3-legged OAuth2 flow
+func (idp *WeChatOAIdProvider) getConfig(clientId string, clientSecret string, redirectUrl string) *oauth2.Config {
+	endpoint := oauth2.Endpoint{
+		TokenURL: "https://graph.qq.com/oauth2.0/token",
+	}
+
+	config := &oauth2.Config{
+		Scopes:       []string{"snsapi_login"},
+		Endpoint:     endpoint,
+		ClientID:     clientId,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectUrl,
+	}
+
+	return config
+}
+
+func (idp *WeChatOAIdProvider) GetToken(code string) (*oauth2.Token, error) {
+	params := url.Values{}
+	params.Add("grant_type", "authorization_code")
+	params.Add("appid", idp.Config.ClientID)
+	params.Add("secret", idp.Config.ClientSecret)
+	params.Add("code", code)
+
+	token := oauth2.Token{
+		AccessToken:  "AccessToken",
+		TokenType:    "WeChatAccessToken",
+		RefreshToken: "RefreshToken",
+		Expiry:       time.Time{},
+	}
+
+	raw := make(map[string]interface{})
+	raw["Openid"] = code
+
+	return token.WithExtra(raw), nil
+}
+
+func (idp *WeChatOAIdProvider) GetUserInfo(token *oauth2.Token) (*UserInfo, error) {
+	openid := token.Extra("Openid").(string)
+	extra := make(map[string]string)
+
+	extra["wechat_unionid"] = openid
+
+	extra[BuildWechatOpenIdKey(idp.Config.ClientID)] = openid
+	userInfo := UserInfo{
+		Id:          openid,
+		Username:    openid,
+		DisplayName: openid,
+		AvatarUrl:   "",
+		Extra:       extra,
+	}
+	return &userInfo, nil
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -61,6 +61,7 @@ func initAPI() {
 	beego.Router("/api/acs", &controllers.ApiController{}, "POST:HandleSamlLogin")
 	beego.Router("/api/saml/metadata", &controllers.ApiController{}, "GET:GetSamlMeta")
 	beego.Router("/api/webhook", &controllers.ApiController{}, "POST:HandleOfficialAccountEvent")
+	beego.Router("/api/webhook", &controllers.ApiController{}, "GET:WXOfficialAccountToken")
 	beego.Router("/api/get-webhook-event", &controllers.ApiController{}, "GET:GetWebhookEventType")
 	beego.Router("/api/get-captcha-status", &controllers.ApiController{}, "GET:GetCaptchaStatus")
 	beego.Router("/api/callback", &controllers.ApiController{}, "POST:Callback")

--- a/web/src/auth/Provider.js
+++ b/web/src/auth/Provider.js
@@ -377,11 +377,10 @@ export function getProviderLogoWidget(provider) {
   }
 }
 
-export function getAuthUrl(application, provider, method) {
+export function getAuthUrl(application, provider, method, res) {
   if (application === null || provider === null) {
     return "";
   }
-
   let endpoint = authInfo[provider.type].endpoint;
   let redirectUri = `${window.location.origin}/callback`;
   const scope = authInfo[provider.type].scope;
@@ -415,11 +414,10 @@ export function getAuthUrl(application, provider, method) {
   } else if (provider.type === "DingTalk") {
     return `${endpoint}?client_id=${provider.clientId}&redirect_uri=${redirectUri}&scope=${scope}&response_type=code&prompt=consent&state=${state}`;
   } else if (provider.type === "WeChat") {
-    if (navigator.userAgent.includes("MicroMessenger")) {
-      return `${authInfo[provider.type].mpEndpoint}?appid=${provider.clientId2}&redirect_uri=${redirectUri}&state=${state}&scope=${authInfo[provider.type].mpScope}&response_type=code#wechat_redirect`;
-    } else {
+    if (provider.clientId !== "") {
       return `${endpoint}?appid=${provider.clientId}&redirect_uri=${redirectUri}&scope=${scope}&response_type=code&state=${state}#wechat_redirect`;
     }
+    return `/callback?appid=${provider.clientId2}&redirect_uri=${redirectUri}&scope=${scope}&response_type=code&state=${state}&code=${res?.data2 || ""}`;
   } else if (provider.type === "WeCom") {
     if (provider.subType === "Internal") {
       if (provider.method === "Silent") {

--- a/web/src/auth/Util.js
+++ b/web/src/auth/Util.js
@@ -192,7 +192,7 @@ export function getEvent(application, provider) {
   getWechatMessageEvent()
     .then(res => {
       if (res.data === "SCAN" || res.data === "subscribe") {
-        Setting.goToLink(Provider.getAuthUrl(application, provider, "signup"));
+        Setting.goToLink(Provider.getAuthUrl(application, provider, "signup", res));
       }
     });
 }


### PR DESCRIPTION
# guide

1. Set the second client key in WeChat configuration and enable QR code scanning
2. Set `<domain>/api/webhook` in the WeChat official account interface configuration, and receive the configuration successfully.
3. Scan the QR code to log in


**Support test account**

https://github.com/casbin/casdoor/issues/2656

