### PR TITLE
feat: ABAC support for /api/enforce endpoint

### DIFF
--- a/util/string.go
+++ b/util/string.go
@@ -324,9 +324,16 @@ func GetUsernameFromEmail(email string) string {
 }
 
 func StringToInterfaceArray(array []string) []interface{} {
-	var interfaceArray []interface{}
-	for _, v := range array {
-		interfaceArray = append(interfaceArray, v)
+	var (
+		interfaceArray []interface{}
+		elem           interface{}
+	)
+	for _, elem = range array {
+		jStruct, err := TryJsonToAnonymousStruct(elem.(string))
+		if err == nil {
+			elem = jStruct
+		}
+		interfaceArray = append(interfaceArray, elem)
 	}
 	return interfaceArray
 }


### PR DESCRIPTION
Hello! 
Recently i tried to enforce permission with ABAC using 'api/enforce' endpoint. I have model with matchers like this: 

`m = r.sub.Id == r.obj.CreatedBy`

And json body like this:

```json
[
    { "Id": "some-uuid-id" }, 
    { "CreatedBy": "some-uuid-id" },
    "delete"
]
```

If i got it right, currently this endpoint cannot handle objects in 'sub' or 'obj' so i implement this simple function to fix this