### PR TITLE
feat: add template support for Custom HTTP SMS provider

### DIFF
--- a/object/sms.go
+++ b/object/sms.go
@@ -27,7 +27,7 @@ func getSmsClient(provider *Provider) (sender.SmsClient, error) {
 	if provider.Type == sender.HuaweiCloud || provider.Type == sender.AzureACS {
 		client, err = sender.NewSmsClient(provider.Type, provider.ClientId, provider.ClientSecret, provider.SignName, provider.TemplateCode, provider.ProviderUrl, provider.AppId)
 	} else if provider.Type == "Custom HTTP SMS" {
-		client, err = newHttpSmsClient(provider.Endpoint, provider.Method, provider.Title)
+		client, err = newHttpSmsClient(provider.Endpoint, provider.Method, provider.Title, provider.TemplateCode)
 	} else {
 		client, err = sender.NewSmsClient(provider.Type, provider.ClientId, provider.ClientSecret, provider.SignName, provider.TemplateCode, provider.AppId)
 	}

--- a/object/sms_custom_http.go
+++ b/object/sms_custom_http.go
@@ -27,20 +27,26 @@ type HttpSmsClient struct {
 	endpoint  string
 	method    string
 	paramName string
+	template  string
 }
 
-func newHttpSmsClient(endpoint string, method string, paramName string) (*HttpSmsClient, error) {
+func newHttpSmsClient(endpoint, method, paramName, template string) (*HttpSmsClient, error) {
+	if template == "" {
+		template = "%s"
+	}
 	client := &HttpSmsClient{
 		endpoint:  endpoint,
 		method:    method,
 		paramName: paramName,
+		template:  template,
 	}
 	return client, nil
 }
 
 func (c *HttpSmsClient) SendMessage(param map[string]string, targetPhoneNumber ...string) error {
 	phoneNumber := targetPhoneNumber[0]
-	content := param["code"]
+	code := param["code"]
+	content := fmt.Sprintf(c.template, code)
 
 	var req *http.Request
 	var err error

--- a/web/src/ProviderEditPage.js
+++ b/web/src/ProviderEditPage.js
@@ -1041,7 +1041,7 @@ class ProviderEditPage extends React.Component {
                 </Row>
                 )
               }
-              {["Custom HTTP SMS", "Infobip SMS"].includes(this.state.provider.type) ?
+              {["Infobip SMS"].includes(this.state.provider.type) ?
                 null :
                 (<Row style={{marginTop: "20px"}} >
                   <Col style={{marginTop: "5px"}} span={(Setting.isMobile()) ? 22 : 2}>


### PR DESCRIPTION
It looks like message templating is not currently supported for the Custom SMS HTTP provider. This PR adds such an opportunity.