### PR TITLE
fix: fix /signup organization parameter issue

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -109,6 +109,11 @@ func (c *ApiController) Signup() {
 		return
 	}
 
+	if organization == nil {
+		c.ResponseError(fmt.Sprintf(c.T("auth:The organization: %s does not exist")), authForm.Organization)
+		return
+	}
+
 	msg := object.CheckUserSignup(application, organization, &authForm, c.GetAcceptLanguage())
 	if msg != "" {
 		c.ResponseError(msg)


### PR DESCRIPTION
The preceding `object.GetOrganization`  can return nil organization causing a panic. Best to handle check gracefully