### PR TITLE
fix: error msg for invalid org & app names in signup

### DIFF
--- a/controllers/account.go
+++ b/controllers/account.go
@@ -94,7 +94,7 @@ func (c *ApiController) Signup() {
 		return
 	}
 	if application == nil {
-		c.ResponseError(fmt.Sprintf(c.T("auth:The application: %s does not exist")), authForm.Application)
+		c.ResponseError(fmt.Sprintf(c.T("auth:The application: %s does not exist"), authForm.Application))
 		return
 	}
 
@@ -110,7 +110,7 @@ func (c *ApiController) Signup() {
 	}
 
 	if organization == nil {
-		c.ResponseError(fmt.Sprintf(c.T("auth:The organization: %s does not exist")), authForm.Organization)
+		c.ResponseError(fmt.Sprintf(c.T("auth:The organization: %s does not exist"), authForm.Organization))
 		return
 	}
 


### PR DESCRIPTION
- These error messages were not capturing the authForm values correctly